### PR TITLE
Make sure ODB driver is connected in extractor

### DIFF
--- a/src/main/kotlin/za/ac/sun/plume/Extractor.kt
+++ b/src/main/kotlin/za/ac/sun/plume/Extractor.kt
@@ -34,6 +34,7 @@ import za.ac.sun.plume.domain.models.vertices.MetaDataVertex
 import za.ac.sun.plume.domain.models.vertices.MethodVertex
 import za.ac.sun.plume.drivers.GremlinDriver
 import za.ac.sun.plume.drivers.IDriver
+import za.ac.sun.plume.drivers.OverflowDbDriver
 import za.ac.sun.plume.graph.ASTBuilder
 import za.ac.sun.plume.graph.CFGBuilder
 import za.ac.sun.plume.graph.CallGraphBuilder
@@ -158,6 +159,7 @@ class Extractor(val driver: IDriver, private val classPath: File) {
     private fun checkDriverConnection(driver: IDriver) {
         when (driver) {
             is GremlinDriver -> if (!driver.connected) driver.connect()
+            is OverflowDbDriver -> if (!driver.connected) driver.connect()
         }
     }
 

--- a/src/main/kotlin/za/ac/sun/plume/drivers/OverflowDbDriver.kt
+++ b/src/main/kotlin/za/ac/sun/plume/drivers/OverflowDbDriver.kt
@@ -35,6 +35,12 @@ class OverflowDbDriver : IDriver {
 
     private val logger = LogManager.getLogger(OverflowDbDriver::class.java)
 
+    /**
+     * Indicates whether the driver is connected to the graph database or not.
+     */
+    var connected = false
+        protected set
+
     private var graph: Graph = createEmptyGraph()
 
     var dbfilename: String = ""


### PR DESCRIPTION
The overflowDB driver allows setting an output filename via `driver.dbfilename($filename)`, however, this is only picked up if `connect` is called. As for gremlin drivers, the extractor must therefore call `driver.connect` on the overflowdb driver.