### PR TITLE
Removing Reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Removed use of reflection to improve performance of serializing and deserializing
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -78,31 +78,31 @@ implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3'
 
 The extractor uses the following dependencies:
 ```groovy
-  implementation 'org.soot-oss:soot:4.2.1'
-  implementation 'org.lz4:lz4-java:1.7.1'
+implementation 'org.soot-oss:soot:4.2.1'
+implementation 'org.lz4:lz4-java:1.7.1'
 ```
 
 Dependencies per graph database technology:
 
 #### _TinkerGraph_
 ```groovy
-    implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
-    implementation 'org.apache.tinkerpop:tinkergraph-gremlin:3.4.8'
+implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
+implementation 'org.apache.tinkerpop:tinkergraph-gremlin:3.4.8'
 ```
 #### _OverflowDb_
 ```groovy
-  implementation 'io.shiftleft:codepropertygraph_2.13:1.3.5'
-  implementation 'io.shiftleft:semanticcpg_2.13:1.3.5'
+implementation 'io.shiftleft:codepropertygraph_2.13:1.3.5'
+implementation 'io.shiftleft:semanticcpg_2.13:1.3.5'
 ```
 #### _JanusGraph_
 ```groovy
-  implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
-  implementation 'org.janusgraph:janusgraph-driver:0.5.2'
+implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
+implementation 'org.janusgraph:janusgraph-driver:0.5.2'
 ```
 #### _TigerGraph_
 ```groovy
-  implementation 'khttp:khttp:1.0.0'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
+implementation 'khttp:khttp:1.0.0'
+implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
 ```
 #### _Amazon Neptune_
 ```groovy
@@ -111,8 +111,8 @@ Dependencies per graph database technology:
 ```
 #### _Neo4j_
 ```groovy
-  implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
-  implementation 'com.steelbridgelabs.oss:neo4j-gremlin-bolt:0.4.4'
+implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
+implementation 'com.steelbridgelabs.oss:neo4j-gremlin-bolt:0.4.4'
 ```
 
 It is not recommended using the fat jar in your project if using a build tool such as Ant, Maven, Gradle, etc. Rather,

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,11 @@ repositories {
 }
 
 dependencies {
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     // Logging
-    implementation "org.apache.logging.log4j:log4j-core:2.13.3"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.13.3"
+    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 
     // Core dependencies
     implementation "org.apache.tinkerpop:gremlin-core:$gremlinVersion"
@@ -42,10 +44,6 @@ dependencies {
     orchidRuntime "io.github.javaeden.orchid:OrchidKotlindoc:$orchidVersion"
     orchidRuntime "io.github.javaeden.orchid:OrchidPluginDocs:$orchidVersion"
     orchidRuntime "io.github.javaeden.orchid:OrchidGithub:$orchidVersion"
-
-    // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
     // Testing
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+
     // Logging
     implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ task allTests(
                 "tigerGraphIntTest",
                 "neo4jIntTest",
                 "extractorTest",
+                "jacocoTestReport"
         ]
 ) { group = "verification" }
 
@@ -153,7 +154,8 @@ dockerCompose {
     }
 }
 
-def artifactDesc = "Plume is a code property graph analysis library with options to extract the CPG from Java bytecode and store the result in various graph databases."
+def artifactDesc = "Plume is a code property graph analysis library with options to extract the CPG from" +
+        " Java bytecode and store the result in various graph databases."
 def repoUrl = "https://github.com/plume-oss/plume.git"
 def artifactVersion = "0.0.3"
 def website = "https://plume-oss.github.io/plume-docs/"
@@ -179,7 +181,8 @@ jacocoTestReport {
         html.destination file("${buildDir}/reports/jacoco")
         csv.enabled false
     }
-    executionData test, extractorTest, tinkerGraphIntTest, overflowDbIntTest, janusGraphIntTest, tigerGraphIntTest, neo4jIntTest
+    executionData test, extractorTest, tinkerGraphIntTest, overflowDbIntTest, janusGraphIntTest, tigerGraphIntTest,
+            neo4jIntTest
 }
 
 check.dependsOn jacocoTestCoverageVerification

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
-kotlinVersion=1.3.72
+kotlinVersion=1.4.21
 
+log4jVersion=2.13.3
 gremlinVersion=3.4.8
 jgVersion=0.5.2
 neo4jGremlinVersion=0.4.5

--- a/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -324,7 +324,8 @@ class Extractor(val driver: IDriver) {
                 logger.debug("Existing class was found and file hashes do not match, marking for rebuild.")
                 // Rebuild
                 driver.getNeighbours(fileV).vertices().filterIsInstance<MethodVertex>().forEach { mtdV ->
-                    logger.debug("Deleting method and saving incoming call graph edges (if any) ${mtdV.fullName} ${mtdV.signature}")
+                    logger.debug("Deleting method and saving incoming call graph edges for " +
+                            "${mtdV.fullName} ${mtdV.signature}")
                     driver.getMethod(mtdV.fullName, mtdV.signature, false).let { g ->
                         g.vertices().filterIsInstance<MethodVertex>().firstOrNull()?.let { mtdV ->
                             driver.getNeighbours(mtdV).edgesIn(mtdV)[EdgeLabel.CALL]
@@ -412,7 +413,7 @@ class Extractor(val driver: IDriver) {
     /**
      * Clears resources of file and graph pointers.
      */
-    fun clear() {
+    private fun clear() {
         loadedFiles.clear()
         classToFileHash.clear()
         sootToPlume.clear()

--- a/src/main/kotlin/io/github/plume/oss/domain/mappers/VertexMapper.kt
+++ b/src/main/kotlin/io/github/plume/oss/domain/mappers/VertexMapper.kt
@@ -4,279 +4,469 @@ import io.github.plume.oss.domain.enums.*
 import io.github.plume.oss.domain.enums.VertexLabel.*
 import io.github.plume.oss.domain.models.PlumeVertex
 import io.github.plume.oss.domain.models.vertices.*
-import kotlin.reflect.KVisibility
-import kotlin.reflect.full.memberProperties
 
 /**
  * Responsible for marshalling and unmarshalling vertex properties to and from [PlumeVertex] objects to [Map] objects.
  */
-class VertexMapper {
-    companion object {
-        /**
-         * Converts a [PlumeVertex]'s properties to a key-value [Map].
-         *
-         * @param v The vertex to serialize.
-         * @return a [MutableMap] of the vertex's
-         */
-        @JvmStatic
-        fun vertexToMap(v: PlumeVertex): MutableMap<String, Any> {
-            val properties = emptyMap<String, Any>().toMutableMap()
-            properties["label"] = v.javaClass.getDeclaredField("LABEL").get(v).toString()
-            v::class.memberProperties.forEach {
-                if (it.visibility == KVisibility.PUBLIC) {
-                    if (it.getter.call(v) is Enum<*>) properties[it.name] = it.getter.call(v).toString()
-                    else properties[it.name] = it.getter.call(v)!!
-                }
+object VertexMapper {
+    /**
+     * Converts a [PlumeVertex]'s properties to a key-value [Map].
+     *
+     * @param v The vertex to serialize.
+     * @return a [MutableMap] of the vertex's
+     */
+    fun vertexToMap(v: PlumeVertex): MutableMap<String, Any> {
+        val properties = emptyMap<String, Any>().toMutableMap()
+        when (v) {
+            is ArrayInitializerVertex -> {
+                properties["label"] = ArrayInitializerVertex.LABEL.name
+                properties["order"] = v.order
             }
-            return properties
-        }
+            is BindingVertex -> {
+                properties["label"] = BindingVertex.LABEL.name
+                properties["name"] = v.name
+                properties["signature"] = v.signature
+            }
+            is BlockVertex -> {
+                properties["label"] = BlockVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+            }
+            is CallVertex -> {
+                properties["label"] = CallVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["dispatchType"] = v.dispatchType.name
+                properties["dynamicTypeHintFullName"] = v.dynamicTypeHintFullName
+                properties["methodFullName"] = v.methodFullName
+                properties["signature"] = v.signature
+                properties["name"] = v.name
 
-        /**
-         * Converts a [Map] containing vertex properties to its respective [PlumeVertex] object.
-         *
-         * @param mapToConvert The [Map] to deserialize.
-         * @return a [PlumeVertex] represented by the information in the given map.
-         */
-        @JvmStatic
-        fun mapToVertex(mapToConvert: Map<String, Any>): PlumeVertex {
-            val map = HashMap<String, Any>()
-            mapToConvert.keys.forEach {
-                when (val value = mapToConvert[it]) {
-                    is Long -> map[it] = value.toInt()
-                    else -> map[it] = value as Any
-                }
             }
-            return when (valueOf(map["label"] as String)) {
-                ARRAY_INITIALIZER -> ArrayInitializerVertex(order = map["order"] as Int)
-                BINDING -> BindingVertex(
-                        name = map["name"] as String,
-                        signature = map["signature"] as String
-                )
-                META_DATA -> MetaDataVertex(
-                        language = map["language"] as String,
-                        version = map["version"] as String
-                )
-                FILE -> FileVertex(
-                        name = map["name"] as String,
-                        hash = map["hash"] as String,
-                        order = map["order"] as Int
-                )
-                METHOD -> MethodVertex(
-                        name = map["name"] as String,
-                        code = map["code"] as String,
-                        fullName = map["fullName"] as String,
-                        signature = map["signature"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int,
-                        order = map["order"] as Int
-                )
-                METHOD_PARAMETER_IN -> MethodParameterInVertex(
-                        code = map["code"] as String,
-                        name = map["name"] as String,
-                        evaluationStrategy = EvaluationStrategy.valueOf(map["evaluationStrategy"] as String),
-                        typeFullName = map["typeFullName"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        order = map["order"] as Int
-                )
-                METHOD_RETURN -> MethodReturnVertex(
-                        code = map["code"] as String,
-                        evaluationStrategy = EvaluationStrategy.valueOf(map["evaluationStrategy"] as String),
-                        typeFullName = map["typeFullName"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int,
-                        order = map["order"] as Int
-                )
-                MODIFIER -> ModifierVertex(
-                        modifierType = ModifierType.valueOf(map["modifierType"] as String),
-                        order = map["order"] as Int
-                )
-                TYPE -> TypeVertex(
-                        name = map["name"] as String,
-                        fullName = map["fullName"] as String,
-                        typeDeclFullName = map["typeDeclFullName"] as String
-                )
-                TYPE_DECL -> TypeDeclVertex(
-                        name = map["name"] as String,
-                        order = map["order"] as Int,
-                        fullName = map["fullName"] as String,
-                        typeDeclFullName = map["typeDeclFullName"] as String
-                )
-                TYPE_PARAMETER -> TypeParameterVertex(
-                        name = map["name"] as String,
-                        order = map["order"] as Int
-                )
-                TYPE_ARGUMENT -> TypeArgumentVertex(
-                        order = map["order"] as Int
-                )
-                MEMBER -> MemberVertex(
-                        code = map["code"] as String,
-                        name = map["name"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        order = map["order"] as Int
-                )
-                NAMESPACE_BLOCK -> NamespaceBlockVertex(
-                        name = map["name"] as String,
-                        fullName = map["fullName"] as String,
-                        order = map["order"] as Int
-                )
-                LITERAL -> LiteralVertex(
-                        code = map["code"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int
-                )
-                CALL -> CallVertex(
-                        code = map["code"] as String,
-                        name = map["name"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        dynamicTypeHintFullName = map["dynamicTypeHintFullName"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        methodFullName = map["methodFullName"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int,
-                        signature = map["signature"] as String,
-                        dispatchType = DispatchType.valueOf(map["dispatchType"] as String)
-                )
-                LOCAL -> LocalVertex(
-                        code = map["code"] as String,
-                        name = map["name"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int,
-                        order = map["order"] as Int
-                )
-                IDENTIFIER -> IdentifierVertex(
-                        code = map["code"] as String,
-                        name = map["name"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                FIELD_IDENTIFIER -> FieldIdentifierVertex(
-                        code = map["code"] as String,
-                        canonicalName = map["canonicalName"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                RETURN -> ReturnVertex(
-                        code = map["code"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                BLOCK -> BlockVertex(
-                        code = map["code"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                METHOD_REF -> MethodRefVertex(
-                        code = map["code"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        methodFullName = map["methodFullName"] as String,
-                        methodInstFullName = map["methodInstFullName"] as String,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                TYPE_REF -> TypeRefVertex(
-                        code = map["code"] as String,
-                        order = map["order"] as Int,
-                        typeFullName = map["typeFullName"] as String,
-                        dynamicTypeFullName = map["dynamicTypeFullName"] as String,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                JUMP_TARGET -> JumpTargetVertex(
-                        name = map["name"] as String,
-                        code = map["code"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                CONTROL_STRUCTURE -> ControlStructureVertex(
-                        code = map["code"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
-                UNKNOWN -> UnknownVertex(
-                        code = map["code"] as String,
-                        typeFullName = map["typeFullName"] as String,
-                        order = map["order"] as Int,
-                        argumentIndex = map["argumentIndex"] as Int,
-                        lineNumber = map["lineNumber"] as Int,
-                        columnNumber = map["columnNumber"] as Int
-                )
+            is ControlStructureVertex -> {
+                properties["label"] = ControlStructureVertex.LABEL.name
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+            }
+            is FieldIdentifierVertex -> {
+                properties["label"] = FieldIdentifierVertex.LABEL.name
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["canonicalName"] = v.canonicalName
+            }
+            is FileVertex -> {
+                properties["label"] = FileVertex.LABEL.name
+                properties["order"] = v.order
+                properties["name"] = v.name
+                properties["hash"] = v.hash
+            }
+            is IdentifierVertex -> {
+                properties["label"] = IdentifierVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["name"] = v.name
+            }
+            is JumpTargetVertex -> {
+                properties["label"] = JumpTargetVertex.LABEL.name
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["name"] = v.name
+            }
+            is LiteralVertex -> {
+                properties["label"] = LiteralVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+            }
+            is LocalVertex -> {
+                properties["label"] = LocalVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["name"] = v.name
+            }
+            is MemberVertex -> {
+                properties["label"] = MemberVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["code"] = v.code
+                properties["name"] = v.name
+            }
+            is MetaDataVertex -> {
+                properties["label"] = MetaDataVertex.LABEL.name
+                properties["language"] = v.language
+                properties["version"] = v.language
+            }
+            is MethodParameterInVertex -> {
+                properties["label"] = MethodParameterInVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["code"] = v.code
+                properties["lineNumber"] = v.lineNumber
+                properties["name"] = v.name
+                properties["evaluationStrategy"] = v.evaluationStrategy.name
+            }
+            is MethodRefVertex -> {
+                properties["label"] = MethodRefVertex.LABEL.name
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["methodFullName"] = v.methodFullName
+                properties["methodInstFullName"] = v.methodInstFullName
+            }
+            is MethodReturnVertex -> {
+                properties["label"] = MethodReturnVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["evaluationStrategy"] = v.evaluationStrategy.name
+            }
+            is MethodVertex -> {
+                properties["label"] = MethodVertex.LABEL.name
+                properties["order"] = v.order
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["signature"] = v.signature
+                properties["name"] = v.name
+                properties["fullName"] = v.fullName
+            }
+            is ModifierVertex -> {
+                properties["label"] = ModifierVertex.LABEL.name
+                properties["order"] = v.order
+                properties["modifierType"] = v.modifierType.name
+            }
+            is NamespaceBlockVertex -> {
+                properties["label"] = NamespaceBlockVertex.LABEL.name
+                properties["order"] = v.order
+                properties["name"] = v.name
+                properties["fullName"] = v.fullName
+            }
+            is ReturnVertex -> {
+                properties["label"] = ReturnVertex.LABEL.name
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+            }
+            is TypeArgumentVertex -> {
+                properties["label"] = TypeArgumentVertex.LABEL.name
+                properties["order"] = v.order
+            }
+            is TypeDeclVertex -> {
+                properties["label"] = TypeDeclVertex.LABEL.name
+                properties["order"] = v.order
+                properties["name"] = v.name
+                properties["fullName"] = v.fullName
+                properties["typeDeclFullName"] = v.typeDeclFullName
+            }
+            is TypeParameterVertex -> {
+                properties["label"] = TypeParameterVertex.LABEL.name
+                properties["order"] = v.order
+                properties["name"] = v.name
+            }
+            is TypeRefVertex -> {
+                properties["label"] = TypeRefVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
+                properties["dynamicTypeFullName"] = v.dynamicTypeFullName
+            }
+            is TypeVertex -> {
+                properties["label"] = TypeVertex.LABEL.name
+                properties["name"] = v.name
+                properties["fullName"] = v.fullName
+                properties["typeDeclFullName"] = v.typeDeclFullName
+            }
+            is UnknownVertex -> {
+                properties["label"] = UnknownVertex.LABEL.name
+                properties["typeFullName"] = v.typeFullName
+                properties["order"] = v.order
+                properties["argumentIndex"] = v.argumentIndex
+                properties["code"] = v.code
+                properties["columnNumber"] = v.columnNumber
+                properties["lineNumber"] = v.lineNumber
             }
         }
+        return properties
+    }
 
-        /**
-         * Checks if the given edge complies with the CPG schema given the from and two vertices.
-         *
-         * @param fromV The vertex from which the edge connects from.
-         * @param toV The vertex to which the edge connects to.
-         * @param edge the edge label between the two vertices.
-         * @return true if the edge complies with the CPG schema, false if otherwise.
-         */
-        @JvmStatic
-        fun checkSchemaConstraints(fromV: PlumeVertex, toV: PlumeVertex, edge: EdgeLabel): Boolean {
-            val fromLabel: VertexLabel = valueOf(vertexToMap(fromV).remove("label")!! as String)
-            val toLabel: VertexLabel = valueOf(vertexToMap(toV).remove("label")!! as String)
-            return checkSchemaConstraints(fromLabel, edge, toLabel)
-        }
-
-        /**
-         * Checks if the given edge complies with the CPG schema given the from and two vertices.
-         *
-         * @param fromLabel The vertex label from which the edge connects from.
-         * @param toLabel The vertex label to which the edge connects to.
-         * @param edge the edge label between the two vertices.
-         * @return true if the edge complies with the CPG schema, false if otherwise.
-         */
-        @JvmStatic
-        fun checkSchemaConstraints(fromLabel: VertexLabel, edge: EdgeLabel, toLabel: VertexLabel): Boolean {
-            return when (fromLabel) {
-                ARRAY_INITIALIZER -> ArrayInitializerVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                BINDING -> BindingVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                META_DATA -> MetaDataVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                FILE -> FileVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                METHOD -> MethodVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                METHOD_PARAMETER_IN -> MethodParameterInVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                METHOD_RETURN -> MethodReturnVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                MODIFIER -> ModifierVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                TYPE -> TypeVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                TYPE_DECL -> TypeDeclVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                TYPE_PARAMETER -> TypeParameterVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                TYPE_ARGUMENT -> TypeArgumentVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                MEMBER -> MemberVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                NAMESPACE_BLOCK -> NamespaceBlockVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                LITERAL -> LiteralVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                CALL -> CallVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                LOCAL -> LocalVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                IDENTIFIER -> IdentifierVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                FIELD_IDENTIFIER -> FieldIdentifierVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                RETURN -> ReturnVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                BLOCK -> BlockVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                METHOD_REF -> MethodRefVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                TYPE_REF -> TypeRefVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                JUMP_TARGET -> JumpTargetVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                CONTROL_STRUCTURE -> ControlStructureVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
-                UNKNOWN -> UnknownVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+    /**
+     * Converts a [Map] containing vertex properties to its respective [PlumeVertex] object.
+     *
+     * @param mapToConvert The [Map] to deserialize.
+     * @return a [PlumeVertex] represented by the information in the given map.
+     */
+    fun mapToVertex(mapToConvert: Map<String, Any>): PlumeVertex {
+        val map = HashMap<String, Any>()
+        mapToConvert.keys.forEach {
+            when (val value = mapToConvert[it]) {
+                is Long -> map[it] = value.toInt()
+                else -> map[it] = value as Any
             }
+        }
+        return when (valueOf(map["label"] as String)) {
+            ARRAY_INITIALIZER -> ArrayInitializerVertex(order = map["order"] as Int)
+            BINDING -> BindingVertex(
+                name = map["name"] as String,
+                signature = map["signature"] as String
+            )
+            META_DATA -> MetaDataVertex(
+                language = map["language"] as String,
+                version = map["version"] as String
+            )
+            FILE -> FileVertex(
+                name = map["name"] as String,
+                hash = map["hash"] as String,
+                order = map["order"] as Int
+            )
+            METHOD -> MethodVertex(
+                name = map["name"] as String,
+                code = map["code"] as String,
+                fullName = map["fullName"] as String,
+                signature = map["signature"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int,
+                order = map["order"] as Int
+            )
+            METHOD_PARAMETER_IN -> MethodParameterInVertex(
+                code = map["code"] as String,
+                name = map["name"] as String,
+                evaluationStrategy = EvaluationStrategy.valueOf(map["evaluationStrategy"] as String),
+                typeFullName = map["typeFullName"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                order = map["order"] as Int
+            )
+            METHOD_RETURN -> MethodReturnVertex(
+                code = map["code"] as String,
+                evaluationStrategy = EvaluationStrategy.valueOf(map["evaluationStrategy"] as String),
+                typeFullName = map["typeFullName"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int,
+                order = map["order"] as Int
+            )
+            MODIFIER -> ModifierVertex(
+                modifierType = ModifierType.valueOf(map["modifierType"] as String),
+                order = map["order"] as Int
+            )
+            TYPE -> TypeVertex(
+                name = map["name"] as String,
+                fullName = map["fullName"] as String,
+                typeDeclFullName = map["typeDeclFullName"] as String
+            )
+            TYPE_DECL -> TypeDeclVertex(
+                name = map["name"] as String,
+                order = map["order"] as Int,
+                fullName = map["fullName"] as String,
+                typeDeclFullName = map["typeDeclFullName"] as String
+            )
+            TYPE_PARAMETER -> TypeParameterVertex(
+                name = map["name"] as String,
+                order = map["order"] as Int
+            )
+            TYPE_ARGUMENT -> TypeArgumentVertex(
+                order = map["order"] as Int
+            )
+            MEMBER -> MemberVertex(
+                code = map["code"] as String,
+                name = map["name"] as String,
+                typeFullName = map["typeFullName"] as String,
+                order = map["order"] as Int
+            )
+            NAMESPACE_BLOCK -> NamespaceBlockVertex(
+                name = map["name"] as String,
+                fullName = map["fullName"] as String,
+                order = map["order"] as Int
+            )
+            LITERAL -> LiteralVertex(
+                code = map["code"] as String,
+                typeFullName = map["typeFullName"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int
+            )
+            CALL -> CallVertex(
+                code = map["code"] as String,
+                name = map["name"] as String,
+                typeFullName = map["typeFullName"] as String,
+                dynamicTypeHintFullName = map["dynamicTypeHintFullName"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                methodFullName = map["methodFullName"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int,
+                signature = map["signature"] as String,
+                dispatchType = DispatchType.valueOf(map["dispatchType"] as String)
+            )
+            LOCAL -> LocalVertex(
+                code = map["code"] as String,
+                name = map["name"] as String,
+                typeFullName = map["typeFullName"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int,
+                order = map["order"] as Int
+            )
+            IDENTIFIER -> IdentifierVertex(
+                code = map["code"] as String,
+                name = map["name"] as String,
+                typeFullName = map["typeFullName"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            FIELD_IDENTIFIER -> FieldIdentifierVertex(
+                code = map["code"] as String,
+                canonicalName = map["canonicalName"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            RETURN -> ReturnVertex(
+                code = map["code"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            BLOCK -> BlockVertex(
+                code = map["code"] as String,
+                typeFullName = map["typeFullName"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            METHOD_REF -> MethodRefVertex(
+                code = map["code"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                methodFullName = map["methodFullName"] as String,
+                methodInstFullName = map["methodInstFullName"] as String,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            TYPE_REF -> TypeRefVertex(
+                code = map["code"] as String,
+                order = map["order"] as Int,
+                typeFullName = map["typeFullName"] as String,
+                dynamicTypeFullName = map["dynamicTypeFullName"] as String,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            JUMP_TARGET -> JumpTargetVertex(
+                name = map["name"] as String,
+                code = map["code"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            CONTROL_STRUCTURE -> ControlStructureVertex(
+                code = map["code"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+            UNKNOWN -> UnknownVertex(
+                code = map["code"] as String,
+                typeFullName = map["typeFullName"] as String,
+                order = map["order"] as Int,
+                argumentIndex = map["argumentIndex"] as Int,
+                lineNumber = map["lineNumber"] as Int,
+                columnNumber = map["columnNumber"] as Int
+            )
+        }
+    }
+
+    /**
+     * Checks if the given edge complies with the CPG schema given the from and two vertices.
+     *
+     * @param fromV The vertex from which the edge connects from.
+     * @param toV The vertex to which the edge connects to.
+     * @param edge the edge label between the two vertices.
+     * @return true if the edge complies with the CPG schema, false if otherwise.
+     */
+    fun checkSchemaConstraints(fromV: PlumeVertex, toV: PlumeVertex, edge: EdgeLabel): Boolean {
+        val fromLabel: VertexLabel = valueOf(vertexToMap(fromV).remove("label")!! as String)
+        val toLabel: VertexLabel = valueOf(vertexToMap(toV).remove("label")!! as String)
+        return checkSchemaConstraints(fromLabel, edge, toLabel)
+    }
+
+    /**
+     * Checks if the given edge complies with the CPG schema given the from and two vertices.
+     *
+     * @param fromLabel The vertex label from which the edge connects from.
+     * @param toLabel The vertex label to which the edge connects to.
+     * @param edge the edge label between the two vertices.
+     * @return true if the edge complies with the CPG schema, false if otherwise.
+     */
+    fun checkSchemaConstraints(fromLabel: VertexLabel, edge: EdgeLabel, toLabel: VertexLabel): Boolean {
+        return when (fromLabel) {
+            ARRAY_INITIALIZER -> ArrayInitializerVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            BINDING -> BindingVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            META_DATA -> MetaDataVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            FILE -> FileVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            METHOD -> MethodVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            METHOD_PARAMETER_IN -> MethodParameterInVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            METHOD_RETURN -> MethodReturnVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            MODIFIER -> ModifierVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            TYPE -> TypeVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            TYPE_DECL -> TypeDeclVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            TYPE_PARAMETER -> TypeParameterVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            TYPE_ARGUMENT -> TypeArgumentVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            MEMBER -> MemberVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            NAMESPACE_BLOCK -> NamespaceBlockVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            LITERAL -> LiteralVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            CALL -> CallVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            LOCAL -> LocalVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            IDENTIFIER -> IdentifierVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            FIELD_IDENTIFIER -> FieldIdentifierVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            RETURN -> ReturnVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            BLOCK -> BlockVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            METHOD_REF -> MethodRefVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            TYPE_REF -> TypeRefVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            JUMP_TARGET -> JumpTargetVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            CONTROL_STRUCTURE -> ControlStructureVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
+            UNKNOWN -> UnknownVertex.VALID_OUT_EDGES[edge]?.contains(toLabel) ?: false
         }
     }
 }

--- a/src/main/kotlin/io/github/plume/oss/domain/mappers/VertexMapper.kt
+++ b/src/main/kotlin/io/github/plume/oss/domain/mappers/VertexMapper.kt
@@ -49,7 +49,6 @@ object VertexMapper {
                 properties["methodFullName"] = v.methodFullName
                 properties["signature"] = v.signature
                 properties["name"] = v.name
-
             }
             is ControlStructureVertex -> {
                 properties["label"] = ControlStructureVertex.LABEL.name

--- a/src/main/kotlin/io/github/plume/oss/drivers/GremlinDriver.kt
+++ b/src/main/kotlin/io/github/plume/oss/drivers/GremlinDriver.kt
@@ -14,8 +14,8 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 import io.github.plume.oss.domain.enums.EdgeLabel
 import io.github.plume.oss.domain.exceptions.PlumeSchemaViolationException
 import io.github.plume.oss.domain.mappers.VertexMapper
-import io.github.plume.oss.domain.mappers.VertexMapper.Companion.checkSchemaConstraints
-import io.github.plume.oss.domain.mappers.VertexMapper.Companion.vertexToMap
+import io.github.plume.oss.domain.mappers.VertexMapper.checkSchemaConstraints
+import io.github.plume.oss.domain.mappers.VertexMapper.vertexToMap
 import io.github.plume.oss.domain.models.PlumeGraph
 import io.github.plume.oss.domain.models.PlumeVertex
 import io.github.plume.oss.domain.models.vertices.FileVertex
@@ -183,12 +183,12 @@ abstract class GremlinDriver : IDriver {
     protected open fun createVertex(v: PlumeVertex): Vertex =
             try {
                 if (!transactionOpen) openTx()
-                val propertyMap = vertexToMap(v)
+                val propertyMap: MutableMap<String, Any> = vertexToMap(v)
                 // Get the implementing class label parameter
-                val label = propertyMap.remove("label") as String?
+                val label = propertyMap.remove("label") as String
                 // Get the implementing classes fields and values
                 g.graph.addVertex(T.label, label, T.id, v.hashCode().toString()).apply {
-                    propertyMap.forEach { (key: String?, value: Any?) -> this.property(key, value) }
+                    propertyMap.forEach { (key: String, value: Any) -> this.property(key, value) }
                 }
             } finally {
                 if (transactionOpen) closeTx()

--- a/src/main/kotlin/io/github/plume/oss/drivers/JanusGraphDriver.kt
+++ b/src/main/kotlin/io/github/plume/oss/drivers/JanusGraphDriver.kt
@@ -7,7 +7,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph
 import org.apache.tinkerpop.gremlin.structure.Transaction
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import io.github.plume.oss.domain.exceptions.PlumeTransactionException
-import io.github.plume.oss.domain.mappers.VertexMapper.Companion.vertexToMap
+import io.github.plume.oss.domain.mappers.VertexMapper.vertexToMap
 import io.github.plume.oss.domain.models.PlumeVertex
 import java.lang.IllegalArgumentException
 

--- a/src/main/kotlin/io/github/plume/oss/drivers/NeptuneDriver.kt
+++ b/src/main/kotlin/io/github/plume/oss/drivers/NeptuneDriver.kt
@@ -7,7 +7,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource.t
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal
 import org.apache.tinkerpop.gremlin.structure.Graph
 import org.apache.tinkerpop.gremlin.structure.Vertex
-import io.github.plume.oss.domain.mappers.VertexMapper.Companion.vertexToMap
+import io.github.plume.oss.domain.mappers.VertexMapper.vertexToMap
 import io.github.plume.oss.domain.models.PlumeVertex
 
 

--- a/src/main/kotlin/io/github/plume/oss/drivers/TigerGraphDriver.kt
+++ b/src/main/kotlin/io/github/plume/oss/drivers/TigerGraphDriver.kt
@@ -8,7 +8,7 @@ import io.github.plume.oss.domain.enums.EdgeLabel
 import io.github.plume.oss.domain.exceptions.PlumeSchemaViolationException
 import io.github.plume.oss.domain.exceptions.PlumeTransactionException
 import io.github.plume.oss.domain.mappers.VertexMapper
-import io.github.plume.oss.domain.mappers.VertexMapper.Companion.checkSchemaConstraints
+import io.github.plume.oss.domain.mappers.VertexMapper.checkSchemaConstraints
 import io.github.plume.oss.domain.models.PlumeGraph
 import io.github.plume.oss.domain.models.PlumeVertex
 import io.github.plume.oss.domain.models.vertices.MetaDataVertex

--- a/src/orchid/resources/homepage.md
+++ b/src/orchid/resources/homepage.md
@@ -78,7 +78,7 @@ implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3'
 
 The extractor uses the following dependencies:
 ```groovy
-  implementation 'org.soot-oss:soot:4.2.1'
+implementation 'org.soot-oss:soot:4.2.1'
 implementation 'org.lz4:lz4-java:1.7.1'
 ```
 
@@ -86,23 +86,23 @@ Dependencies per graph database technology:
 
 #### _TinkerGraph_
 ```groovy
-    implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
-    implementation 'org.apache.tinkerpop:tinkergraph-gremlin:3.4.8'
+implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
+implementation 'org.apache.tinkerpop:tinkergraph-gremlin:3.4.8'
 ```
 #### _OverflowDb_
 ```groovy
-  implementation 'io.shiftleft:codepropertygraph_2.13:1.3.5'
-  implementation 'io.shiftleft:semanticcpg_2.13:1.3.5'
+implementation 'io.shiftleft:codepropertygraph_2.13:1.3.5'
+implementation 'io.shiftleft:semanticcpg_2.13:1.3.5'
 ```
 #### _JanusGraph_
 ```groovy
-  implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
-  implementation 'org.janusgraph:janusgraph-driver:0.5.2'
+implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
+implementation 'org.janusgraph:janusgraph-driver:0.5.2'
 ```
 #### _TigerGraph_
 ```groovy
-  implementation 'khttp:khttp:1.0.0'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
+implementation 'khttp:khttp:1.0.0'
+implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
 ```
 #### _Amazon Neptune_
 ```groovy
@@ -111,7 +111,7 @@ Dependencies per graph database technology:
 ```
 #### _Neo4j_
 ```groovy
-  implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
+implementation 'org.apache.tinkerpop:gremlin-core:3.4.8'
 implementation 'com.steelbridgelabs.oss:neo4j-gremlin-bolt:0.4.4'
 ```
 

--- a/src/test/kotlin/io/github/plume/oss/domain/MapperTest.kt
+++ b/src/test/kotlin/io/github/plume/oss/domain/MapperTest.kt
@@ -1,11 +1,11 @@
 package io.github.plume.oss.domain
 
+import io.github.plume.oss.TestDomainResources.Companion.vertices
+import io.github.plume.oss.domain.enums.VertexLabel
+import io.github.plume.oss.domain.mappers.VertexMapper
+import io.github.plume.oss.domain.models.vertices.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
-import io.github.plume.oss.TestDomainResources.Companion.vertices
-import io.github.plume.oss.domain.mappers.VertexMapper
-import kotlin.reflect.full.memberProperties
 
 
 class MapperTest {
@@ -14,14 +14,211 @@ class MapperTest {
     fun propertiesToMapTest() {
         vertices.forEach { v ->
             val map = VertexMapper.vertexToMap(v)
-            map.remove("label")
-            map.forEach { entry ->
-                val property = v::class.memberProperties.find { it.name == entry.key }
-                        ?: fail("Could not resolve property ${entry.key} from map")
-                if (property.getter.call(v) is Enum<*>)
-                    assertEquals(entry.value, (property.getter.call(v) as Enum<*>).name)
-                else
-                    assertEquals(entry.value, property.getter.call(v))
+            val lbl = map.remove("label") as String
+            when (VertexLabel.valueOf(lbl)) {
+                VertexLabel.ARRAY_INITIALIZER -> {
+                    v as ArrayInitializerVertex
+                    assertEquals(v.order, map["order"])
+                }
+                VertexLabel.BINDING -> {
+                    v as BindingVertex
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.signature, map["signature"])
+                }
+                VertexLabel.BLOCK -> {
+                    v as BlockVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                }
+                VertexLabel.CALL -> {
+                    v as CallVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.dispatchType.name, map["dispatchType"])
+                    assertEquals(v.dynamicTypeHintFullName, map["dynamicTypeHintFullName"])
+                    assertEquals(v.methodFullName, map["methodFullName"])
+                    assertEquals(v.signature, map["signature"])
+                    assertEquals(v.name, map["name"])
+
+                }
+                VertexLabel.CONTROL_STRUCTURE -> {
+                    v as ControlStructureVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                }
+                VertexLabel.FIELD_IDENTIFIER -> {
+                    v as FieldIdentifierVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.canonicalName, map["canonicalName"])
+                }
+                VertexLabel.FILE -> {
+                    v as FileVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.hash, map["hash"])
+                }
+                VertexLabel.IDENTIFIER -> {
+                    v as IdentifierVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.name, map["name"])
+                }
+                VertexLabel.JUMP_TARGET -> {
+                    v as JumpTargetVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.name, map["name"])
+                }
+                VertexLabel.LITERAL -> {
+                    v as LiteralVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                }
+                VertexLabel.LOCAL -> {
+                    v as LocalVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.name, map["name"])
+                }
+                VertexLabel.MEMBER -> {
+                    v as MemberVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.name, map["name"])
+                }
+                VertexLabel.META_DATA -> {
+                    v as MetaDataVertex
+                    assertEquals(v.language, map["language"])
+                    assertEquals(v.language, map["version"])
+                }
+                VertexLabel.METHOD_PARAMETER_IN -> {
+                    v as MethodParameterInVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.evaluationStrategy.name, map["evaluationStrategy"])
+                }
+                VertexLabel.METHOD_REF -> {
+                    v as MethodRefVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.methodFullName, map["methodFullName"])
+                    assertEquals(v.methodInstFullName, map["methodInstFullName"])
+                }
+                VertexLabel.METHOD_RETURN -> {
+                    v as MethodReturnVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.evaluationStrategy.name, map["evaluationStrategy"])
+                }
+                VertexLabel.METHOD -> {
+                    v as MethodVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.signature, map["signature"])
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.fullName, map["fullName"])
+                }
+                VertexLabel.MODIFIER -> {
+                    v as ModifierVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.modifierType.name, map["modifierType"])
+                }
+                VertexLabel.NAMESPACE_BLOCK -> {
+                    v as NamespaceBlockVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.fullName, map["fullName"])
+                }
+                VertexLabel.RETURN -> {
+                    v as ReturnVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                }
+                VertexLabel.TYPE_ARGUMENT -> {
+                    v as TypeArgumentVertex
+                    assertEquals(v.order, map["order"])
+                }
+                VertexLabel.TYPE_DECL -> {
+                    v as TypeDeclVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.fullName, map["fullName"])
+                    assertEquals(v.typeDeclFullName, map["typeDeclFullName"])
+                }
+                VertexLabel.TYPE_PARAMETER -> {
+                    v as TypeParameterVertex
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.name, map["name"])
+                }
+                VertexLabel.TYPE_REF -> {
+                    v as TypeRefVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                    assertEquals(v.dynamicTypeFullName, map["dynamicTypeFullName"])
+                }
+                VertexLabel.TYPE -> {
+                    v as TypeVertex
+                    assertEquals(v.name, map["name"])
+                    assertEquals(v.fullName, map["fullName"])
+                    assertEquals(v.typeDeclFullName, map["typeDeclFullName"])
+                }
+                VertexLabel.UNKNOWN -> {
+                    v as UnknownVertex
+                    assertEquals(v.typeFullName, map["typeFullName"])
+                    assertEquals(v.order, map["order"])
+                    assertEquals(v.argumentIndex, map["argumentIndex"])
+                    assertEquals(v.code, map["code"])
+                    assertEquals(v.columnNumber, map["columnNumber"])
+                    assertEquals(v.lineNumber, map["lineNumber"])
+                }
             }
         }
     }

--- a/src/test/kotlin/io/github/plume/oss/domain/MapperTest.kt
+++ b/src/test/kotlin/io/github/plume/oss/domain/MapperTest.kt
@@ -1,10 +1,11 @@
 package io.github.plume.oss.domain
 
 import io.github.plume.oss.TestDomainResources.Companion.vertices
+import io.github.plume.oss.domain.enums.EdgeLabel
 import io.github.plume.oss.domain.enums.VertexLabel
 import io.github.plume.oss.domain.mappers.VertexMapper
 import io.github.plume.oss.domain.models.vertices.*
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 
@@ -228,6 +229,326 @@ class MapperTest {
         vertices.forEach { v ->
             val map = VertexMapper.vertexToMap(v)
             assertEquals(v, VertexMapper.mapToVertex(map))
+        }
+    }
+
+    @Test
+    fun vertexConstraintsTest() {
+        vertices.forEach { src ->
+            when (src) {
+                is ArrayInitializerVertex -> {
+                    val clazz = ArrayInitializerVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is BindingVertex -> {
+                    val clazz = BindingVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is BlockVertex -> {
+                    val clazz = BlockVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is CallVertex -> {
+                    val clazz = CallVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is ControlStructureVertex -> {
+                    val clazz = ControlStructureVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is FieldIdentifierVertex -> {
+                    val clazz = FieldIdentifierVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is FileVertex -> {
+                    val clazz = FileVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is IdentifierVertex -> {
+                    val clazz = IdentifierVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is JumpTargetVertex -> {
+                    val clazz = JumpTargetVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is LiteralVertex -> {
+                    val clazz = LiteralVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is LocalVertex -> {
+                    val clazz = LocalVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is MemberVertex -> {
+                    val clazz = MemberVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is MetaDataVertex -> {
+                    val clazz = MetaDataVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is MethodParameterInVertex -> {
+                    val clazz = MethodParameterInVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is MethodRefVertex -> {
+                    val clazz = MethodRefVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is MethodReturnVertex -> {
+                    val clazz = MethodReturnVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is MethodVertex -> {
+                    val clazz = MethodVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is ModifierVertex -> {
+                    val clazz = ModifierVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is NamespaceBlockVertex -> {
+                    val clazz = NamespaceBlockVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is ReturnVertex -> {
+                    val clazz = ReturnVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is TypeArgumentVertex -> {
+                    val clazz = TypeArgumentVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is TypeDeclVertex -> {
+                    val clazz = TypeDeclVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is TypeParameterVertex -> {
+                    val clazz = TypeParameterVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is TypeRefVertex -> {
+                    val clazz = TypeRefVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is TypeVertex -> {
+                    val clazz = TypeVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+                is UnknownVertex -> {
+                    val clazz = UnknownVertex
+                    EdgeLabel.values().forEach { e ->
+                        VertexLabel.values().forEach { tgt ->
+                            if (clazz.VALID_OUT_EDGES.containsKey(e) && clazz.VALID_OUT_EDGES[e]!!.contains(tgt)) {
+                                assertTrue(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            } else {
+                                assertFalse(VertexMapper.checkSchemaConstraints(clazz.LABEL, e, tgt))
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/io/github/plume/oss/drivers/OverflowDbDriverIntTest.kt
+++ b/src/test/kotlin/io/github/plume/oss/drivers/OverflowDbDriverIntTest.kt
@@ -53,7 +53,8 @@ class OverflowDbDriverIntTest {
         @AfterAll
         @JvmStatic
         fun tearDownAll() {
-            println("${OverflowDbDriverIntTest::class.java.simpleName} completed in ${(System.nanoTime() - testStartTime) / 1e6} ms")
+            println("${OverflowDbDriverIntTest::class.java.simpleName} completed in " +
+                    "${(System.nanoTime() - testStartTime) / 1e6} ms")
         }
     }
 
@@ -64,7 +65,6 @@ class OverflowDbDriverIntTest {
             overflow = true
             heapPercentageThreshold = 90
             storageLocation = OverflowDbDriverIntTest.storageLocation
-            connect()
         }
         assertFalse(driver.serializationStatsEnabled)
         assertTrue(driver.overflow)

--- a/src/test/kotlin/io/github/plume/oss/drivers/OverflowDbDriverIntTest.kt
+++ b/src/test/kotlin/io/github/plume/oss/drivers/OverflowDbDriverIntTest.kt
@@ -65,6 +65,7 @@ class OverflowDbDriverIntTest {
             overflow = true
             heapPercentageThreshold = 90
             storageLocation = OverflowDbDriverIntTest.storageLocation
+            connect()
         }
         assertFalse(driver.serializationStatsEnabled)
         assertTrue(driver.overflow)

--- a/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
+++ b/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
@@ -10,12 +10,12 @@ import io.github.plume.oss.Extractor
 import io.github.plume.oss.domain.models.vertices.*
 import io.github.plume.oss.drivers.DriverFactory
 import io.github.plume.oss.drivers.GraphDatabase
-import io.github.plume.oss.drivers.TinkerGraphDriver
+import io.github.plume.oss.drivers.OverflowDbDriver
 import java.io.File
 
 class BasicExtractorTest {
     companion object {
-        private val driver = DriverFactory(GraphDatabase.TINKER_GRAPH) as TinkerGraphDriver
+        private val driver = DriverFactory(GraphDatabase.OVERFLOWDB) as OverflowDbDriver
         private val TEST_PATH = "extractor_tests${File.separator}"
         private lateinit var extractor: Extractor
         private lateinit var validSourceFile: File


### PR DESCRIPTION
Since reflection is slow as it denies the JVM from certain optimizations, it has been removed from Plume to improve type safety and performance.