### PR TITLE
Log schema violations but do not crash

### DIFF
--- a/src/main/kotlin/io/github/plume/oss/drivers/OverflowDbDriver.kt
+++ b/src/main/kotlin/io/github/plume/oss/drivers/OverflowDbDriver.kt
@@ -366,7 +366,8 @@ class OverflowDbDriver : IDriver {
         try {
             srcNode.addEdge(edge.name, dstNode)
         } catch (exc: RuntimeException) {
-            throw PlumeSchemaViolationException(fromV, toV, edge)
+            val msg = "CPG schema violation adding a ${edge.name} edge from ${fromV.javaClass.simpleName} to ${toV.javaClass.simpleName}"
+            logger.warn(msg)
         }
     }
 


### PR DESCRIPTION
While testing plume via `joern-parse`, I ran into quiet a few silent crashes caused by schema violation exceptions. If we do fail to add an edge because it would violate the schema, we should report that, but there is not need to crash altogether.