### PR TITLE
Catch and log schema violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+
+### Fixed
+
+## [0.0.3] - 2020-12-23
+
+### Changed
 - Removed use of reflection to improve performance of serializing and deserializing
+- Extractor now longer halts process if a schema violation occurs
+- ShiftLeft dependencies upgraded
 
 ### Fixed
 - Argument index was not being implemented properly, this has been fixed.


### PR DESCRIPTION
To prevent the extraction process from halting on a schema violation, these should be caught and logged as warnings instead.