### PR TITLE
Fix for `getProgramStructure` in ODB driver

### DIFF
--- a/cpgconv/src/main/scala/io/github/plume/oss/Traversals.scala
+++ b/cpgconv/src/main/scala/io/github/plume/oss/Traversals.scala
@@ -46,15 +46,22 @@ object Traversals {
       .asJava
   }
 
+  import overflowdb.traversal._
   def getProgramStructure(graph: Graph): util.List[Edge] = {
-    Cpg(graph).file
+    val edgesFromFile: List[Edge] = Cpg(graph).file
       .outE(EdgeTypes.AST)
-      .filter { x =>
-        x.inNode()
-          .isInstanceOf[nodes.NamespaceBlock]
+      .filter(_.inNode().isInstanceOf[nodes.NamespaceBlock])
+      .l
+    val edgesFromNamespaceBlock: List[Edge] = edgesFromFile
+      .to(Traversal)
+      .inV
+      .collect {
+        case x: nodes.NamespaceBlock =>
+          x.outE(EdgeTypes.AST).filter(_.inNode().isInstanceOf[nodes.NamespaceBlock]).l
       }
       .l
-      .asJava
+      .flatten
+    (edgesFromFile ++ edgesFromNamespaceBlock).asJava
   }
 
   def getNeighbours(graph: Graph, nodeId: Long): util.List[Edge] = {

--- a/cpgconv/src/main/scala/io/github/plume/oss/Traversals.scala
+++ b/cpgconv/src/main/scala/io/github/plume/oss/Traversals.scala
@@ -7,6 +7,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, HasOrder, StoredNode}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.{Edge, Graph}
+import io.shiftleft.codepropertygraph.generated.nodes
 
 import scala.jdk.CollectionConverters._
 
@@ -46,7 +47,14 @@ object Traversals {
   }
 
   def getProgramStructure(graph: Graph): util.List[Edge] = {
-    Cpg(graph).file.ast.outE(EdgeTypes.AST).l.asJava
+    Cpg(graph).file
+      .outE(EdgeTypes.AST)
+      .filter { x =>
+        x.inNode()
+          .isInstanceOf[nodes.NamespaceBlock]
+      }
+      .l
+      .asJava
   }
 
   def getNeighbours(graph: Graph, nodeId: Long): util.List[Edge] = {
@@ -56,14 +64,21 @@ object Traversals {
       .flatMap { f =>
         List(f) ++ f.astChildren
       }
-      .inE.l.asJava
+      .inE
+      .l
+      .asJava
   }
 
   def getVertexIds(graph: Graph, lowerBound: Long, upperBound: Long): util.Set[Long] = {
     Cpg(graph).all
-      .map { x => x.id() }
-      .filter { id => lowerBound to upperBound contains id }
-      .toSet.asJava
+      .map { x =>
+        x.id()
+      }
+      .filter { id =>
+        lowerBound to upperBound contains id
+      }
+      .toSet
+      .asJava
   }
 
   def clearGraph(graph: Graph): Unit = {


### PR DESCRIPTION
The function `getProgramStructure` as implemented for the overflowdb driver mistakenly returned all edges as opposed to just return the edges between file nodes and namespace blocks. This PR fixes that. Also ran `gradlew scalafmt`, which resulted in a bit of reformatting in `getNeighbours` and `getVertexIds`.

This fixes https://github.com/ShiftLeftSecurity/joern/issues/450