### PR TITLE
Soot Causes RuntimeException When Unable to Get Active Body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Fixed
+- When Soot cannot get method data, it will log this as a warning 
+  instead of throwing a `RuntimeException`
 
 ## [0.1.4] - 2021-02-08
 

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -255,39 +255,16 @@ class Extractor(val driver: IDriver) {
         // Setup defaults
         setUpDefaultStructure()
         // Load all methods to construct the CPG from and convert them to UnitGraph objects
-        val graphs = classStream.asSequence()
-            .map { it.methods.filter { mtd -> mtd.isConcrete }.toList() }.flatten()
-            .let {
-                if (ExtractorOptions.callGraphAlg == ExtractorOptions.CallGraphAlg.NONE)
-                    it else it.map(this::addExternallyReferencedMethods).flatten()
-            }
-            .distinct().toList().let { if (it.size >= 100000) it.parallelStream() else it.stream() }
-            .filter { !it.isPhantom }.map { m ->
-                runCatching { BriefUnitGraph(m.retrieveActiveBody()) }
-                    .onFailure { logger.warn("Unable to get method body for method ${m.name}.") }
-                    .getOrNull()
-            }.asSequence().filterNotNull().toList()
+        val graphs = constructUnitGraphs(classStream)
         // Build external types from fields and locals
-        val createExtTypes = { stream: Sequence<soot.Type> ->
-            stream.distinct()
-                .filter { t -> !classStream.any { it.name == t.toString() } }
-                .filter {
-                    !programStructure.nodes(TYPE_DECL).asSequence().any { n -> n.property(FULL_NAME) == it.toString() }
-                }
-                .map { t -> buildTypeDeclaration(t).apply { driver.addVertex(this) } }
-                .forEach { t ->
-                    // Connect external type decls to the unknown file vert
-                    getSootAssociation("<unknown>")?.let {
-                        it.firstOrNull()?.let { f -> driver.addEdge(t, f, SOURCE_FILE) }
-                    }
-                    // Connect type decls to their modifiers
-                    obtainModifiersFromTypeDeclVert(t).forEachIndexed { i, m ->
-                        driver.addEdge(t, NewModifierBuilder().modifiertype(m).order(i + 1), AST)
-                    }
-                }
-        }
-        createExtTypes(classStream.asSequence().map { it.fields }.flatten().map { it.type })
-        createExtTypes(graphs.asSequence().map { it.body.locals + it.body.parameterLocals }.flatten().map { it.type })
+        createExternalTypes(
+            classStream = classStream,
+            typeStream = classStream.asSequence().map { it.fields }.flatten().map { it.type }
+        )
+        createExternalTypes(
+            classStream = classStream,
+            typeStream = graphs.asSequence().map { it.body.locals + it.body.parameterLocals }.flatten().map { it.type }
+        )
         // Construct the CPGs for methods
         graphs.map(this::constructCPG)
             .toList().asSequence()
@@ -298,6 +275,51 @@ class Extractor(val driver: IDriver) {
         graphs.forEach { SootToPlumeUtil.connectMethodToTypeDecls(it.body.method, driver) }
         clear()
     }
+
+    /**
+     * Creates [TypeDecl] from external [soot.Type]s. This also links the [TypeDecl]s to their modifiers and the
+     * unknown file vertex.
+     *
+     * @param classStream The stream of application [SootClass] to separate external classes from.
+     * @param typeStream The stream of all [soot.Type]s.
+     */
+    private fun createExternalTypes(classStream: List<SootClass>, typeStream: Sequence<soot.Type>) {
+        typeStream.distinct()
+            .filter { t -> !classStream.any { it.name == t.toString() } }
+            .filter {
+                !programStructure.nodes(TYPE_DECL).asSequence().any { n -> n.property(FULL_NAME) == it.toString() }
+            }
+            .map { t -> buildTypeDeclaration(t).apply { driver.addVertex(this) } }
+            .forEach { t ->
+                // Connect external type decls to the unknown file vert
+                getSootAssociation("<unknown>")?.let {
+                    it.firstOrNull()?.let { f -> driver.addEdge(t, f, SOURCE_FILE) }
+                }
+                // Connect type decls to their modifiers
+                obtainModifiersFromTypeDeclVert(t).forEachIndexed { i, m ->
+                    driver.addEdge(t, NewModifierBuilder().modifiertype(m).order(i + 1), AST)
+                }
+            }
+    }
+
+    /**
+     * Load all methods to construct the CPG from and convert them to [UnitGraph] objects.
+     *
+     * @param classStream A stream of [SootClass] to construct [BriefUnitGraph] from.
+     * @return a list of [BriefUnitGraph] objects.
+     */
+    private fun constructUnitGraphs(classStream: List<SootClass>) = classStream.asSequence()
+        .map { it.methods.filter { mtd -> mtd.isConcrete }.toList() }.flatten()
+        .let {
+            if (ExtractorOptions.callGraphAlg == ExtractorOptions.CallGraphAlg.NONE)
+                it else it.map(this::addExternallyReferencedMethods).flatten()
+        }
+        .distinct().toList().let { if (it.size >= 100000) it.parallelStream() else it.stream() }
+        .filter { !it.isPhantom }.map { m ->
+            runCatching { BriefUnitGraph(m.retrieveActiveBody()) }
+                .onFailure { logger.warn("Unable to get method body for method ${m.name}.") }
+                .getOrNull()
+        }.asSequence().filterNotNull().toList()
 
     /**
      * Sets up default vertices for placeholders like unknown files.


### PR DESCRIPTION
When Soot is unable to get the body of a method it will now log this as a warning under `%TEMP/plume/plume.log`.

Resolves #57 