### PR TITLE
Fixed Invalid Call Edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Module not found bug introduced by improper class cleanup in temp dir.
+- Fixed instances where CallGraphBuilder would connect non-NewCallBuilder source nodes to methods. 
+- Fixed GraphML not escaping ampersands
 
 ## [0.1.6] - 2021-02-10
 

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -81,6 +81,10 @@ class Extractor(val driver: IDriver) {
     private lateinit var programStructure: Graph
 
     init {
+        File(COMP_DIR).let { f ->
+            if (f.exists()) f.deleteRecursively()
+            f.deleteOnExit()
+        }
         checkDriverConnection(driver)
         astBuilder = ASTBuilder(driver)
         cfgBuilder = CFGBuilder(driver)
@@ -188,7 +192,7 @@ class Extractor(val driver: IDriver) {
      */
     @Throws(PlumeCompileException::class, NullPointerException::class, IOException::class)
     fun load(f: File) {
-        if (!File(COMP_DIR).exists()) File(COMP_DIR).mkdirs()
+        File(COMP_DIR).let { c -> if (!c.exists()) c.mkdirs() }
         if (!f.exists()) {
             throw NullPointerException("File '${f.name}' does not exist!")
         } else if (f.isDirectory) {

--- a/plume/src/main/kotlin/io/github/plume/oss/graph/CallGraphBuilder.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/graph/CallGraphBuilder.kt
@@ -59,7 +59,7 @@ class CallGraphBuilder(private val driver: IDriver) : IGraphBuilder {
             // If Soot points to the assignment as the call source then this is most likely from the rightOp. Let's
             // hope this is not the source of a bug
             val srcUnit = if (unit is AssignStmt) unit.rightOp else unit
-            getSootAssociation(srcUnit)?.firstOrNull()?.let { srcPlumeVertex ->
+            getSootAssociation(srcUnit)?.filterIsInstance<NewCallBuilder>()?.firstOrNull()?.let { srcPlumeVertex ->
                 val tgtPlumeVertex = getSootAssociation(e.tgt.method())?.firstOrNull()
                     ?: constructPhantom(e.tgt.method(), driver)
                 runCatching {

--- a/plume/src/main/kotlin/io/github/plume/oss/graphio/GraphMLWriter.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/graphio/GraphMLWriter.kt
@@ -84,7 +84,10 @@ object GraphMLWriter {
 
     private fun escape(o: Any) =
         when (o) {
-            is String -> o.replace("<", "&lt;").replace(">", "&gt;")
+            is String -> o
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("&", "&amp;")
             is `$colon$colon`<*> -> o.head()
             is `Nil$` -> ""
             else -> o.toString()

--- a/plume/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
+++ b/plume/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
@@ -110,7 +110,6 @@ class BasicExtractorTest {
         extractor.load(validJarFile)
         extractor.project()
         g = driver.getWholeGraph()
-        GraphMLWriter.write(g, FileWriter("/tmp/plume/x.xml"))
         g = driver.getProgramStructure()
         val ns = g.nodes().asSequence().toList()
         ns.filterIsInstance<ODBFile>().let { fileList ->


### PR DESCRIPTION
- Fixed instances where `CallGraphBuilder` would connect non-`NewCallBuilder` source nodes to methods.
- Clean up build directory on `Extractor` init
- Fixed `GraphML` not escaping ampersands