### PR TITLE
Fix: Neo4j String Escape and TypeRef - ArrayInitializer Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - yyyy-mm-dd
+## [0.2.4] - 2021-02-26
 
 ### Added
 
 ### Changed
 
 ### Fixed
+- Escape " (quotes) to fix Neo4j bug where strings containing quotes fail vertex insertion 
 
 ## [0.2.3] - 2021-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `code`, `lineNumber`, `columnNumber` to `ArrayInitializer`
 
-### Changed
-
 ### Fixed
 - Escape " (quotes) to fix Neo4j bug where strings containing quotes fail vertex insertion
 - `TypeDecl` to `ArrayInitializer` edge warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.2.4] - 2021-02-26
 
 ### Added
+- `code`, `lineNumber`, `columnNumber` to `ArrayInitializer`
 
 ### Changed
 
 ### Fixed
-- Escape " (quotes) to fix Neo4j bug where strings containing quotes fail vertex insertion 
+- Escape " (quotes) to fix Neo4j bug where strings containing quotes fail vertex insertion
+- `TypeDecl` to `ArrayInitializer` edge warning
 
 ## [0.2.3] - 2021-02-25
 

--- a/plume/build.gradle
+++ b/plume/build.gradle
@@ -177,7 +177,7 @@ dockerCompose {
 def artifactDesc = "Plume is a code property graph analysis library with options to extract the CPG from" +
         " Java bytecode and store the result in various graph databases."
 def repoUrl = "https://github.com/plume-oss/plume.git"
-def artifactVersion = "0.2.3.2"
+def artifactVersion = "0.2.4"
 def website = "https://plume-oss.github.io/plume-docs/"
 
 group = "io.github.plume-oss"

--- a/plume/src/main/kotlin/io/github/plume/oss/domain/mappers/VertexMapper.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/domain/mappers/VertexMapper.kt
@@ -58,6 +58,9 @@ object VertexMapper {
         return when (map["label"] as String) {
             ArrayInitializer.Label() -> NewArrayInitializerBuilder()
                 .order(map[ORDER] as Int)
+                .code(map[CODE] as String)
+                .lineNumber(Option.apply(map[LINE_NUMBER] as Int))
+                .columnNumber(Option.apply(map[COLUMN_NUMBER] as Int))
             Binding.Label() -> NewBindingBuilder()
                 .name(map[NAME] as String)
                 .signature(map[SIGNATURE] as String)

--- a/plume/src/main/kotlin/io/github/plume/oss/drivers/Neo4jDriver.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/drivers/Neo4jDriver.kt
@@ -128,6 +128,16 @@ class Neo4jDriver internal constructor() : IDriver {
         return attributes
     }
 
+    private fun sanitizePayload(p: String): String =
+        p.replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\'", "\\\'")
+            .replace("\n", "\\\n")
+            .replace("\t", "\\\t")
+            .replace("\b", "\\\b")
+            .replace("\r", "\\\r")
+            .replace("\\f", "\\\\f")
+
     override fun addVertex(v: NewNodeBuilder) {
         val node = v.build()
         val propertyMap = CollectionConverters.MapHasAsJava(node.properties()).asJava().toMutableMap()
@@ -137,7 +147,9 @@ class Neo4jDriver internal constructor() : IDriver {
             val attributeList = extractAttributesFromMap(propertyMap).toList()
             attributeList.forEachIndexed { i: Int, e: Pair<String, Any> ->
                 payload.append("${e.first}:")
-                if (e.second is String) payload.append("\"${e.second}\"") else payload.append(e.second)
+                val p = e.second
+                if (p is String) payload.append("\"${sanitizePayload(p)}\"")
+                else payload.append(p)
                 if (i < attributeList.size - 1) payload.append(",")
             }
             payload.append("}")

--- a/plume/src/main/kotlin/io/github/plume/oss/graph/ASTBuilder.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/graph/ASTBuilder.kt
@@ -520,27 +520,15 @@ class ASTBuilder(private val driver: IDriver) : IGraphBuilder {
         }
     }
 
-    private fun createNewArrayExpr(expr: NewArrayExpr, childIdx: Int = 0): NewTypeRefBuilder {
-        val newArrayExprVertices = mutableListOf<NewNodeBuilder>()
-        val typeRef = NewTypeRefBuilder()
-            .typeFullName(expr.type.toQuotedString())
+    private fun createNewArrayExpr(expr: NewArrayExpr, childIdx: Int = 0) =
+        NewArrayInitializerBuilder()
+            .order(childIdx + 1)
+            .argumentIndex(childIdx + 1)
             .code(expr.toString())
-            .argumentIndex(childIdx)
-            .order(childIdx)
             .lineNumber(Option.apply(currentLine))
             .columnNumber(Option.apply(currentCol))
             .apply { addSootToPlumeAssociation(expr, this) }
-        NewArrayInitializerBuilder()
-            .order(childIdx)
-            .let {
-                runCatching {
-                    driver.addEdge(typeRef, it, AST)
-                }.onFailure { e -> logger.warn(e.message) }
-                newArrayExprVertices.add(it)
-            }
-        addSootToPlumeAssociation(expr, newArrayExprVertices)
-        return typeRef
-    }
+
 
     private fun projectReturnVertex(ret: ReturnStmt, childIdx: Int): NewReturnBuilder {
         val retV = NewReturnBuilder()

--- a/plume/src/main/kotlin/io/github/plume/oss/graph/PDGBuilder.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/graph/PDGBuilder.kt
@@ -19,10 +19,7 @@ import io.github.plume.oss.Extractor.Companion.getSootAssociation
 import io.github.plume.oss.drivers.IDriver
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.ARGUMENT
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.REF
-import io.shiftleft.codepropertygraph.generated.nodes.NewCallBuilder
-import io.shiftleft.codepropertygraph.generated.nodes.NewIdentifierBuilder
-import io.shiftleft.codepropertygraph.generated.nodes.NewLocalBuilder
-import io.shiftleft.codepropertygraph.generated.nodes.NewMethodParameterInBuilder
+import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.apache.logging.log4j.LogManager
 import soot.Local
 import soot.jimple.*
@@ -62,9 +59,9 @@ class PDGBuilder(private val driver: IDriver) : IGraphBuilder {
 
     private fun projectCallArg(value: Any) {
         getSootAssociation(value)?.firstOrNull { it is NewCallBuilder }?.let { src ->
-            getSootAssociation(value)?.filter { it != src }?.forEach {
+            getSootAssociation(value)?.filterNot { it == src || it is NewArrayInitializerBuilder }?.forEach { tgt ->
                 runCatching {
-                    driver.addEdge(src, it, ARGUMENT)
+                    driver.addEdge(src, tgt, ARGUMENT)
                 }.onFailure { e -> logger.warn(e.message) }
             }
         }

--- a/plume/src/test/kotlin/io/github/plume/oss/TestDomainResources.kt
+++ b/plume/src/test/kotlin/io/github/plume/oss/TestDomainResources.kt
@@ -27,7 +27,8 @@ class TestDomainResources {
         val BOOL_1 = false
 
         val vertices = listOf<NewNodeBuilder>(
-            NewArrayInitializerBuilder().order(INT_1),
+            NewArrayInitializerBuilder().order(INT_1).code(STRING_1).lineNumber(Option.apply(INT_1))
+                .columnNumber(Option.apply(INT_1)),
             NewBindingBuilder().name(STRING_1).signature(STRING_2),
             NewBlockBuilder().typeFullName(STRING_1).code(STRING_1).order(INT_1).argumentIndex(INT_1)
                 .lineNumber(Option.apply(INT_1)).columnNumber(Option.apply(INT_1)),


### PR DESCRIPTION
### Added
- `code`, `lineNumber`, `columnNumber` to `ArrayInitializer`

### Fixed
- Escape " (quotes) to fix Neo4j bug where strings containing quotes fail vertex insertion
- `TypeDecl` to `ArrayInitializer` edge warning
