### PR TITLE
Using Cached Method Bodies Instead of Fetching Method Bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `BaseCpgPass` which is a combination of the `ASTPass`, `CFGPass`, and `PDGPass` and returns a `DeltaGraph` instead of
   directly apply changes to the driver.
 - `methodBodies` was added to `GlobalCache` to save on database requests when moving to `SCPGPass` after `BaseCpgPass`
+- Chunk size can now be configured via `ExtractorOptions::methodChunkSize`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `DeltaGraph` as a `NewNodeBuilder` variant of ShiftLeft's `DiffGraph`.
 - `BaseCpgPass` which is a combination of the `ASTPass`, `CFGPass`, and `PDGPass` and returns a `DeltaGraph` instead of
   directly apply changes to the driver.
+- `methodBodies` was added to `GlobalCache` to save on database requests when moving to `SCPGPass` after `BaseCpgPass`
 
 ### Changed
 
 - Replaced `ASTPass`, `CFGPass`, and `PDGPass` with `BaseCpgPass`.
-- Spawns a thread pool to run base CPG building in parallel and apply `DeltaGraph`s in serial. 
+- Spawns a thread pool to run base CPG building in parallel and apply `DeltaGraph`s in serial.
+- SCPG flows are only run on new/updated method bodies since the analysis is independent of other methods.
 
 ## [0.3.2] - 2021-03-12
 

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -303,7 +303,7 @@ class Extractor(val driver: IDriver) {
                 val dg = BaseCPGPass(g).runPass()
                 channel.send(dg)
                 val (fullName, _, _) = SootToPlumeUtil.methodToStrings(g.body.method)
-                GlobalCache.methodBodies[fullName] = dg.toOverflowDb()
+                GlobalCache.methodBodies[fullName] = dg
             }
         }
     }

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -29,7 +29,8 @@ import io.github.plume.oss.metrics.ExtractorTimeKey
 import io.github.plume.oss.metrics.PlumeTimer
 import io.github.plume.oss.options.ExtractorOptions
 import io.github.plume.oss.passes.SCPGPass
-import io.github.plume.oss.passes.graph.*
+import io.github.plume.oss.passes.graph.BaseCPGPass
+import io.github.plume.oss.passes.graph.CGPass
 import io.github.plume.oss.passes.method.MethodStubPass
 import io.github.plume.oss.passes.structure.ExternalTypePass
 import io.github.plume.oss.passes.structure.FileAndPackagePass
@@ -277,11 +278,13 @@ class Extractor(val driver: IDriver) {
         }
         // Clear all Soot resources and cache
         clear()
+        GlobalCache.clear()
         /*
-            Method body level analysis. This runs over all in-case dataflow information changes on update.
+            Method body level analysis - only done on new/updated methods
          */
         logger.info("Running SCPG passes")
         PlumeTimer.measure(ExtractorTimeKey.SCPG_PASSES) { SCPGPass(driver).runPass() }
+        GlobalCache.methodBodies.clear()
         return this
     }
 
@@ -295,7 +298,14 @@ class Extractor(val driver: IDriver) {
      */
     private fun buildBaseCPGs(gs: List<BriefUnitGraph>, channel: Channel<DeltaGraph>) = runBlocking {
         // Producer: Create local instances of CPGs from BriefUnitGraphs map changes to DeltaGraphs
-        gs.forEach { g -> launch { channel.send(BaseCPGPass(g).runPass()) } }
+        gs.forEach { g ->
+            launch {
+                val dg = BaseCPGPass(g).runPass()
+                channel.send(dg)
+                val (fullName, _, _) = SootToPlumeUtil.methodToStrings(g.body.method)
+                GlobalCache.methodBodies[fullName] = dg.toOverflowDb()
+            }
+        }
     }
 
     /**
@@ -384,7 +394,6 @@ class Extractor(val driver: IDriver) {
      */
     private fun clear() {
         loadedFiles.clear()
-        GlobalCache.clear()
         File(COMP_DIR).deleteRecursively()
         G.reset()
     }

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -252,7 +252,7 @@ class Extractor(val driver: IDriver) {
                 existingMs.contains(fullName)
             }.toList()
             runBlocking {
-                val chunkSize = 25
+                val chunkSize = ExtractorOptions.methodChunkSize
                 val jobCount = bodiesToBuild.size
                 val nThreads = (jobCount / chunkSize)
                     .coerceAtLeast(1)

--- a/plume/src/main/kotlin/io/github/plume/oss/GlobalCache.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/GlobalCache.kt
@@ -1,7 +1,9 @@
 package io.github.plume.oss
 
 import io.shiftleft.codepropertygraph.generated.nodes.*
+import overflowdb.Graph
 import soot.SootClass
+import soot.SootMethod
 import soot.toolkits.graph.BriefUnitGraph
 import java.util.concurrent.ConcurrentHashMap
 
@@ -13,6 +15,11 @@ object GlobalCache {
     private val sootToPlume = ConcurrentHashMap<Any, MutableList<NewNodeBuilder>>()
     private val fHashes = ConcurrentHashMap<SootClass, String>()
     private val savedCallGraphEdges = ConcurrentHashMap<String, MutableList<NewCallBuilder>>()
+
+    /**
+     * Caches already built method bodies to save database requests during SCPG passes.
+     */
+    val methodBodies = mutableMapOf<String, Graph>()
 
     /**
      * Associates the given Soot object to the given [NewNode].

--- a/plume/src/main/kotlin/io/github/plume/oss/GlobalCache.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/GlobalCache.kt
@@ -1,9 +1,8 @@
 package io.github.plume.oss
 
+import io.github.plume.oss.domain.model.DeltaGraph
 import io.shiftleft.codepropertygraph.generated.nodes.*
-import overflowdb.Graph
 import soot.SootClass
-import soot.SootMethod
 import soot.toolkits.graph.BriefUnitGraph
 import java.util.concurrent.ConcurrentHashMap
 
@@ -19,7 +18,7 @@ object GlobalCache {
     /**
      * Caches already built method bodies to save database requests during SCPG passes.
      */
-    val methodBodies = mutableMapOf<String, Graph>()
+    val methodBodies = mutableMapOf<String, DeltaGraph>()
 
     /**
      * Associates the given Soot object to the given [NewNode].

--- a/plume/src/main/kotlin/io/github/plume/oss/options/ExtractorOptions.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/options/ExtractorOptions.kt
@@ -32,6 +32,11 @@ object ExtractorOptions {
      */
     val sparkOpts = mutableMapOf<String, String>()
 
+    /**
+     * Specifies how large each chunk should be when giving a thread method bodies to project into base CPGs.
+     */
+    var methodChunkSize = 25
+
     init {
         sparkOpts["verbose"] = "false"
         sparkOpts["propagator"] = "worklist"

--- a/plume/src/main/kotlin/io/github/plume/oss/passes/SCPGPass.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/passes/SCPGPass.kt
@@ -39,7 +39,7 @@ class SCPGPass(private val driver: IDriver) {
             val bufferedChannel = Channel<Graph>()
             val g = Graph.open(Config.withDefaults(), NodeFactories.allAsJava(), EdgeFactories.allAsJava())
             // Producer
-            GlobalCache.methodBodies.values.forEach { mg -> launch { bufferedChannel.send(mg) } }
+            GlobalCache.methodBodies.values.forEach { mg -> launch { bufferedChannel.send(mg.toOverflowDb()) } }
             // Single consumer
             launch {
                 repeat(GlobalCache.methodBodies.size) {

--- a/plume/src/main/kotlin/io/github/plume/oss/passes/SCPGPass.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/passes/SCPGPass.kt
@@ -36,8 +36,7 @@ class SCPGPass(private val driver: IDriver) {
      */
     fun runPass() {
         runBlocking {
-            // We use a semaphore to avoid spamming the database with too many requests
-            val bufferedChannel = Channel<Graph>(10)
+            val bufferedChannel = Channel<Graph>()
             val g = Graph.open(Config.withDefaults(), NodeFactories.allAsJava(), EdgeFactories.allAsJava())
             // Producer
             GlobalCache.methodBodies.values.forEach { mg -> launch { bufferedChannel.send(mg) } }

--- a/plume/src/test/kotlin/io/github/plume/oss/domain/DeltaGraphTest.kt
+++ b/plume/src/test/kotlin/io/github/plume/oss/domain/DeltaGraphTest.kt
@@ -10,6 +10,7 @@ import io.github.plume.oss.drivers.GraphDatabase
 import io.github.plume.oss.drivers.TinkerGraphDriver
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.AST
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.SOURCE_FILE
+import io.shiftleft.codepropertygraph.generated.NodeTypes.*
 import org.apache.logging.log4j.LogManager
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -82,11 +83,11 @@ class DeltaGraphTest {
 
     @Test
     fun testCompoundOperations() {
-        DeltaGraph.Builder().addVertex(fileVertex)
+        val b = DeltaGraph.Builder().addVertex(fileVertex)
             .addEdge(methodVertex, fileVertex, SOURCE_FILE)
             .addEdge(methodVertex, localVertex, AST)
             .build()
-            .apply(driver)
+        b.apply(driver)
         assertTrue(fileVertex.id() > -1L)
         assertTrue(methodVertex.id() > -1L)
         assertTrue(localVertex.id() > -1L)
@@ -101,6 +102,12 @@ class DeltaGraphTest {
             val e2 = g.edges(AST).next()
             assertEquals(localVertex.id(), e2.inNode().id())
             assertEquals(methodVertex.id(), e2.outNode().id())
+        }
+        b.toOverflowDb().use { g ->
+            assertEquals(1, g.nodeCount(FILE))
+            assertEquals(1, g.nodeCount(METHOD))
+            assertEquals(1, g.nodeCount(LOCAL))
+            assertEquals(2, g.edgeCount())
         }
     }
 

--- a/plume/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
+++ b/plume/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
@@ -4,6 +4,7 @@ import io.github.plume.oss.Extractor
 import io.github.plume.oss.drivers.DriverFactory
 import io.github.plume.oss.drivers.GraphDatabase
 import io.github.plume.oss.drivers.OverflowDbDriver
+import io.github.plume.oss.options.ExtractorOptions
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.codepropertygraph.generated.nodes.Local
@@ -41,6 +42,7 @@ class BasicExtractorTest {
             validClassFile = getTestResource("${TEST_PATH}Test2.class")
             validJarFile = getTestResource("${TEST_PATH}Test3.jar")
             validDirectory = getTestResource("${TEST_PATH}dir_test")
+            ExtractorOptions.methodChunkSize = 5
             extractor = Extractor(driver)
         }
     }

--- a/plume/src/test/kotlin/io/github/plume/oss/extractor/UpdateGraphTest.kt
+++ b/plume/src/test/kotlin/io/github/plume/oss/extractor/UpdateGraphTest.kt
@@ -4,7 +4,6 @@ import io.github.plume.oss.Extractor
 import io.github.plume.oss.drivers.DriverFactory
 import io.github.plume.oss.drivers.GraphDatabase
 import io.github.plume.oss.drivers.TinkerGraphDriver
-import io.shiftleft.codepropertygraph.generated.EdgeTypes.REACHING_DEF
 import io.shiftleft.codepropertygraph.generated.nodes.Literal
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
@@ -63,11 +62,7 @@ class UpdateGraphTest {
         assertTrue(literalsG1.none { it.code() == "9" })
         assertFalse(g1 == g2)
         assertEquals(g1.nodeCount(), g2.nodeCount())
-        // Don't compare calculation edges
-        assertEquals(
-            g1.edges().asSequence().filterNot { it.label() == REACHING_DEF }.toList().size,
-            g2.edges().asSequence().filterNot { it.label() == REACHING_DEF }.toList().size
-        )
+        assertEquals(g1.edgeCount(), g2.edgeCount())
         g1.close()
         g2.close()
     }


### PR DESCRIPTION
### Added

- `methodBodies` was added to `GlobalCache` to save on database requests when moving to `SCPGPass` after `BaseCpgPass`

### Changed

- SCPG flows are only run on new/updated method bodies since the analysis is independent of other methods.

Resolves #107 