### PR TITLE
Improved Cache Options and Added EVAL_TYPE to Method Head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `IDriver.bulkTransaction` to replace `DeltaGraph.apply` and make database specific bulk changes.
+- `EVAL_TYPE` links for `MethodReturn` and `BlockVertex` on the method stubs.
+
+### Fixed
+- `CacheOptions.cacheSize` is mutable via setters now
 
 ### Changed
 
@@ -19,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Feedback regarding files to updated now moved from `INFO` to `DEBUG` logging.
 - Marked `DeltaGraph.apply` as deprecated.
 - `DeltaGraph::toOverflowDb` now only writes to an existing OverflowDB instance.
+- Increased `CacheOptions.cacheSize` and the cache is now partitioned among the 4 caches
+  based on average allocation from the benchmarks. Cache expiry is now removed as an option.
 
 ## [0.3.9] - 2021-03-23
 

--- a/plume/src/main/kotlin/io/github/plume/oss/options/CacheOptions.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/options/CacheOptions.kt
@@ -1,19 +1,12 @@
 package io.github.plume.oss.options
 
-import java.util.concurrent.TimeUnit
-
 /**
  * Cache options to specify how Plume's caching policy is specified.
  */
 object CacheOptions {
 
     /**
-     * How long items should be kept in the cache (after write) before being evicted. Default 1 hour.
+     * How many items may be kept in total in the cache. Default 10 000.
      */
-    val cacheExpiry: Pair<Long, TimeUnit> = Pair(1L, TimeUnit.HOURS)
-
-    /**
-     * How many items may be kept in any given cache. Default 5000.
-     */
-    val cacheSize: Long = 5_000L
+    var cacheSize: Long = 10_000L
 }

--- a/plume/src/main/kotlin/io/github/plume/oss/passes/method/MethodStubPass.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/passes/method/MethodStubPass.kt
@@ -72,10 +72,18 @@ class MethodStubPass(private val m: SootMethod) : IMethodPass {
             .argumentIndex(0)
             .lineNumber(Option.apply(currentLine))
             .columnNumber(Option.apply(currentCol))
-            .apply { builder.addEdge(mtdVertex, this, AST); PlumeStorage.storeMethodNode(m, this) }
+            .apply {
+                builder.addEdge(mtdVertex, this, AST)
+                PlumeStorage.storeMethodNode(m, this)
+                LocalCache.getType("void")?.let { void -> builder.addEdge(this, void, EVAL_TYPE) }
+            }
         // Store return type
         val mtdRet = projectMethodReturnVertex(m.returnType, currentLine, currentCol, childIdx++)
-            .apply { builder.addEdge(mtdVertex, this, AST); PlumeStorage.storeMethodNode(m, this) }
+            .apply {
+                builder.addEdge(mtdVertex, this, AST)
+                PlumeStorage.storeMethodNode(m, this)
+                LocalCache.getType(this.build().typeFullName())?.let { void -> builder.addEdge(this, void, EVAL_TYPE) }
+            }
         // Extrapolate certain information manually for external classes
         if (!m.declaringClass.isApplicationClass) {
             // Create a call-to-return for external classes

--- a/plume/src/main/kotlin/io/github/plume/oss/store/LocalCache.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/store/LocalCache.kt
@@ -6,6 +6,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.NewFileBuilder
 import io.shiftleft.codepropertygraph.generated.nodes.NewNamespaceBlockBuilder
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeBuilder
 import io.shiftleft.codepropertygraph.generated.nodes.NewTypeDeclBuilder
+import org.apache.logging.log4j.LogManager
 import org.cache2k.Cache
 import org.cache2k.Cache2kBuilder
 
@@ -15,34 +16,33 @@ import org.cache2k.Cache2kBuilder
  */
 object LocalCache {
 
-    private val typeCache: Cache<String, NewTypeBuilder> =
-        object : Cache2kBuilder<String, NewTypeBuilder>() {}
-            .name("typeCache")
-            .expireAfterWrite(CacheOptions.cacheExpiry.first, CacheOptions.cacheExpiry.second)
-            .entryCapacity(CacheOptions.cacheSize)
-            .disableStatistics(true)
-            .build()
-    private val typeDeclCache: Cache<String, NewTypeDeclBuilder> =
-        object : Cache2kBuilder<String, NewTypeDeclBuilder>() {}
-            .name("typeDeclCache")
-            .expireAfterWrite(CacheOptions.cacheExpiry.first, CacheOptions.cacheExpiry.second)
-            .entryCapacity(CacheOptions.cacheSize)
-            .disableStatistics(true)
-            .build()
-    private val fileCache: Cache<String, NewFileBuilder> =
-        object : Cache2kBuilder<String, NewFileBuilder>() {}
-            .name("fileCache")
-            .expireAfterWrite(CacheOptions.cacheExpiry.first, CacheOptions.cacheExpiry.second)
-            .entryCapacity(CacheOptions.cacheSize)
-            .disableStatistics(true)
-            .build()
-    private val namespaceBlockCache: Cache<String, NewNamespaceBlockBuilder> =
-        object : Cache2kBuilder<String, NewNamespaceBlockBuilder>() {}
-            .name("namespaceBlockCache")
-            .expireAfterWrite(CacheOptions.cacheExpiry.first, CacheOptions.cacheExpiry.second)
-            .entryCapacity(CacheOptions.cacheSize)
-            .disableStatistics(true)
-            .build()
+    private val logger = LogManager.getLogger(LocalCache::javaClass)
+
+    private val typeCache: Cache<String, NewTypeBuilder>
+    private val typeDeclCache: Cache<String, NewTypeDeclBuilder>
+    private val fileCache: Cache<String, NewFileBuilder>
+    private val namespaceBlockCache: Cache<String, NewNamespaceBlockBuilder>
+
+    init {
+        val typeDeclSize = (CacheOptions.cacheSize * 0.26).toLong()
+        val typeSize = (CacheOptions.cacheSize * 0.26).toLong()
+        val fileSize = (CacheOptions.cacheSize * 0.24).toLong()
+        val namespaceBlockSize = (CacheOptions.cacheSize * 0.24).toLong()
+        typeCache = object : Cache2kBuilder<String, NewTypeBuilder>() {}
+            .name("typeCache").entryCapacity(typeSize).build()
+        typeDeclCache = object : Cache2kBuilder<String, NewTypeDeclBuilder>() {}
+            .name("typeDeclCache").entryCapacity(typeDeclSize).build()
+        fileCache = object : Cache2kBuilder<String, NewFileBuilder>() {}
+            .name("fileCache").entryCapacity(fileSize).build()
+        namespaceBlockCache = object : Cache2kBuilder<String, NewNamespaceBlockBuilder>() {}
+            .name("namespaceBlockCache").entryCapacity(namespaceBlockSize).build()
+        logger.info("Configured cache size is ${CacheOptions.cacheSize}.")
+        logger.debug("Assigning cache as follows => " +
+                "(TYPE, $typeSize), " +
+                "(TYPE_DECL, $typeDeclSize), " +
+                "(FILE, $fileSize), " +
+                "(NAMESPACE_BLOCK, $namespaceBlockSize)")
+    }
 
     fun removeType(fullName: String) = typeCache.remove(fullName)
 


### PR DESCRIPTION
### Added

- `EVAL_TYPE` links for `MethodReturn` and `BlockVertex` on the method stubs.

### Fixed
- `CacheOptions.cacheSize` is mutable via setters now

### Changed

- Increased `CacheOptions.cacheSize` and the cache is now partitioned among the 4 caches
  based on average allocation from the benchmarks. Cache expiry is now removed as an option.