### PR TITLE
Handle Array Index Accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `ArrayRef` now gets projects as an `Operators.indexAccess` call with index and base identifier as the arguments.
+
 ### Changed
 
 - `ThrowStmt` is now an `Unknown` vertex where control flow ends at.
+- `NewArrayExpr` is now an `Unknown` vertex.
 
 ## [0.3.10] - 2021-03-29
 

--- a/plume/src/main/kotlin/io/github/plume/oss/util/SootToPlumeUtil.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/util/SootToPlumeUtil.kt
@@ -165,24 +165,6 @@ object SootToPlumeUtil {
             .columnNumber(Option.apply(currentCol))
 
     /**
-     * Creates a [NewIdentifier] from an [ArrayRef].
-     */
-    fun createArrayRefIdentifier(
-        arrRef: ArrayRef,
-        currentLine: Int,
-        currentCol: Int,
-        childIdx: Int = 1
-    ): NewIdentifierBuilder =
-        NewIdentifierBuilder()
-            .code(arrRef.toString())
-            .name(arrRef.toString())
-            .order(childIdx)
-            .argumentIndex(arrRef.index.toString().toIntOrNull() ?: childIdx)
-            .typeFullName(arrRef.type.toQuotedString())
-            .lineNumber(Option.apply(currentLine))
-            .columnNumber(Option.apply(currentCol))
-
-    /**
      * Creates a [NewFieldIdentifier] from a [FieldRef].
      */
     fun createFieldIdentifierVertex(


### PR DESCRIPTION
### Added

- `ArrayRef` now gets projects as an `Operators.indexAccess` call with index and base identifier as the arguments.

### Changed

- `NewArrayExpr` is now an `Unknown` vertex.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
