### PR TITLE
ReachingDefs now optional 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade ShiftLeft dependencies to 1.3.236
 - Removed `Binding` vertices
 - Can now handle new type arguments API of domain classes
+- `Extractor::project` now takes an optional boolean to disable reaching defs calculation
+- `Extractor::projectReachingDefs` now calculates reaching defs separately
 
 ## [0.5.12] - 2021-07-30
 

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -180,6 +180,9 @@ class Extractor(val driver: IDriver) {
     /**
      * Projects all loaded classes to the graph database. This expects that all application files part of the artifact
      * are loaded.
+     *
+     * @param includeReachingDefs if true, will include calculating REACHING_DEF chains. If false, will keep method CPGs
+     * in memory storage.
      */
     fun project(includeReachingDefs: Boolean = true): Extractor {
         /*
@@ -347,7 +350,8 @@ class Extractor(val driver: IDriver) {
     }
 
     /**
-     * Runs reaching defs analysis - necessary for data-flow analysis queries i.e. reachableBy()
+     * Runs reaching defs analysis - necessary for data-flow analysis queries i.e. reachableBy(). Will not make changes
+     * if [project] ran in default mode i.e. project(includeReachingDefs = true).
      */
     fun projectReachingDefs() {
         logger.info("Running data flow passes")

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -181,7 +181,7 @@ class Extractor(val driver: IDriver) {
      * Projects all loaded classes to the graph database. This expects that all application files part of the artifact
      * are loaded.
      */
-    fun project(): Extractor {
+    fun project(includeReachingDefs: Boolean = true): Extractor {
         /*
             Load and compile files then feed them into Soot
          */
@@ -335,13 +335,24 @@ class Extractor(val driver: IDriver) {
             PlumeTimer.measure(ExtractorTimeKey.BASE_CPG_BUILDING) { buildMethods(methodsToBuild, sootUnitGraphs) }
         // Clear all Soot resources and storage
         this.clear()
-        /*
-            Method body level analysis - only done on new/updated methods
-         */
+        if (includeReachingDefs) {
+            /*
+                Method body level analysis - only done on new/updated methods
+             */
+            logger.info("Running data flow passes")
+            PlumeTimer.measure(ExtractorTimeKey.DATA_FLOW_PASS) { DataFlowPass(driver).runPass() }
+            PlumeStorage.methodCpgs.clear()
+        }
+        return this
+    }
+
+    /**
+     * Runs reaching defs analysis - necessary for data-flow analysis queries i.e. reachableBy()
+     */
+    fun projectReachingDefs() {
         logger.info("Running data flow passes")
         PlumeTimer.measure(ExtractorTimeKey.DATA_FLOW_PASS) { DataFlowPass(driver).runPass() }
         PlumeStorage.methodCpgs.clear()
-        return this
     }
 
     private fun earlyStopCleanUp() {

--- a/plume/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
+++ b/plume/src/test/kotlin/io/github/plume/oss/extractor/BasicExtractorTest.kt
@@ -63,7 +63,8 @@ class BasicExtractorTest {
     @Test
     fun validSourceFileTest() {
         extractor.load(validSourceFile)
-        extractor.project()
+        extractor.project(false)
+        extractor.projectReachingDefs()
         g = driver.getWholeGraph()
         val ns = g.nodes().asSequence().toList()
         assertNotNull(ns.filterIsInstance<NamespaceBlock>().find { it.name() == "extractor_tests" })

--- a/testing/src/test/scala/io/github/plume/oss/PlumeCodeToCpgSuite.scala
+++ b/testing/src/test/scala/io/github/plume/oss/PlumeCodeToCpgSuite.scala
@@ -18,7 +18,7 @@ class PlumeFrontend extends LanguageFrontend {
     Using(DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]) { driver =>
       driver.storageLocation(cpgFile.getAbsolutePath)
       val extractor = new Extractor(driver)
-      extractor.load(sourceCodeFile).project()
+      extractor.load(sourceCodeFile).project(true)
       LocalCache.INSTANCE.clear()
     }
     val odbConfig = overflowdb.Config.withDefaults().withStorageLocation(cpgFile.getAbsolutePath)


### PR DESCRIPTION
### Changed

- `Extractor::project` now takes an optional boolean to disable reaching defs calculation
- `Extractor::projectReachingDefs` now calculates reaching defs separately

### Related issues:

None

### Reviewer

@DavidBakerEffendi
