### PR TITLE
ODB Generated from codepropertygraph CPG Calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `Extractor::project` now generated overloaded methods for Java
+
+### Changed
+
+- OverflowDB graphs now generated from `io.shiftleft.codepropertygraph.generated.Cpg`
+
 ## [0.5.13] - 2021-09-07
 
 ### Changed

--- a/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/Extractor.kt
@@ -184,6 +184,7 @@ class Extractor(val driver: IDriver) {
      * @param includeReachingDefs if true, will include calculating REACHING_DEF chains. If false, will keep method CPGs
      * in memory storage.
      */
+    @JvmOverloads
     fun project(includeReachingDefs: Boolean = true): Extractor {
         /*
             Load and compile files then feed them into Soot

--- a/plume/src/main/kotlin/io/github/plume/oss/drivers/GremlinDriver.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/drivers/GremlinDriver.kt
@@ -21,6 +21,7 @@ import io.github.plume.oss.domain.mappers.VertexMapper.checkSchemaConstraints
 import io.github.plume.oss.domain.model.DeltaGraph
 import io.github.plume.oss.metrics.DriverTimeKey
 import io.github.plume.oss.metrics.PlumeTimer
+import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.AST
 import io.shiftleft.codepropertygraph.generated.NodeTypes.*
 import io.shiftleft.codepropertygraph.generated.PropertyNames.FULL_NAME
@@ -481,10 +482,6 @@ abstract class GremlinDriver : IDriver {
         }
     }
 
-    protected fun newOverflowGraph(): overflowdb.Graph = overflowdb.Graph.open(
-        Config.withDefaults(),
-        NodeFactories.allAsJava(),
-        EdgeFactories.allAsJava()
-    )
+    protected fun newOverflowGraph(): overflowdb.Graph = Cpg.emptyGraph()
 
 }

--- a/plume/src/main/kotlin/io/github/plume/oss/drivers/Neo4jDriver.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/drivers/Neo4jDriver.kt
@@ -22,6 +22,7 @@ import io.github.plume.oss.domain.mappers.VertexMapper.mapToVertex
 import io.github.plume.oss.domain.model.DeltaGraph
 import io.github.plume.oss.metrics.DriverTimeKey
 import io.github.plume.oss.metrics.PlumeTimer
+import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.AST
 import io.shiftleft.codepropertygraph.generated.EdgeTypes.SOURCE_FILE
 import io.shiftleft.codepropertygraph.generated.NodeTypes.*
@@ -645,11 +646,7 @@ class Neo4jDriver internal constructor() : IDriver {
         return l
     }
 
-    private fun newOverflowGraph(): Graph = Graph.open(
-        Config.withDefaults(),
-        NodeFactories.allAsJava(),
-        EdgeFactories.allAsJava()
-    )
+    private fun newOverflowGraph(): Graph = Cpg.emptyGraph()
 
     companion object {
         /**

--- a/plume/src/main/kotlin/io/github/plume/oss/drivers/OverflowDbDriver.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/drivers/OverflowDbDriver.kt
@@ -22,6 +22,7 @@ import io.github.plume.oss.domain.mappers.VertexMapper.checkSchemaConstraints
 import io.github.plume.oss.domain.model.DeltaGraph
 import io.github.plume.oss.metrics.DriverTimeKey
 import io.github.plume.oss.metrics.PlumeTimer
+import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.*
 import org.apache.logging.log4j.LogManager
 import overflowdb.*
@@ -317,10 +318,6 @@ class OverflowDbDriver internal constructor() : IDriver {
         }
     }
 
-    private fun newOverflowGraph(odbConfig: Config = Config.withDefaults()): Graph = Graph.open(
-        odbConfig,
-        NodeFactories.allAsJava(),
-        EdgeFactories.allAsJava()
-    )
+    private fun newOverflowGraph(odbConfig: Config = Config.withDefaults()): Graph = Cpg.withConfig(odbConfig).graph()
 
 }

--- a/plume/src/main/kotlin/io/github/plume/oss/drivers/TigerGraphDriver.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/drivers/TigerGraphDriver.kt
@@ -27,6 +27,7 @@ import io.github.plume.oss.util.ExtractorConst
 import io.github.plume.oss.util.ExtractorConst.BOOLEAN_TYPES
 import io.github.plume.oss.util.ExtractorConst.INT_TYPES
 import io.github.plume.oss.util.PlumeKeyProvider
+import io.shiftleft.codepropertygraph.generated.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.NodeTypes.*
@@ -686,11 +687,7 @@ class TigerGraphDriver internal constructor() : IOverridenIdDriver, ISchemaSafeD
         return out.toString()
     }
 
-    private fun newOverflowGraph(): Graph = Graph.open(
-        Config.withDefaults(),
-        NodeFactories.allAsJava(),
-        EdgeFactories.allAsJava()
-    )
+    private fun newOverflowGraph(): Graph = Cpg.emptyGraph()
 
     /**
      * Uses the generated schema from [TigerGraphDriver.buildSchemaPayload] and remotely executes it on the database.

--- a/testing/src/test/scala/io/github/plume/oss/PlumeCodeToCpgSuite.scala
+++ b/testing/src/test/scala/io/github/plume/oss/PlumeCodeToCpgSuite.scala
@@ -18,7 +18,7 @@ class PlumeFrontend extends LanguageFrontend {
     Using(DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]) { driver =>
       driver.storageLocation(cpgFile.getAbsolutePath)
       val extractor = new Extractor(driver)
-      extractor.load(sourceCodeFile).project(true)
+      extractor.load(sourceCodeFile).project()
       LocalCache.INSTANCE.clear()
     }
     val odbConfig = overflowdb.Config.withDefaults().withStorageLocation(cpgFile.getAbsolutePath)


### PR DESCRIPTION
### Added

- `Extractor::project` now generated overloaded methods for Java

### Changed

- OverflowDB graphs now generated from `io.shiftleft.codepropertygraph.generated.Cpg`

### Related issues:

None

### Reviewer

@DavidBakerEffendi
