### PR TITLE
Fixed TableSwitchStmt child orderings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `TableSwitchStmt` jump targets now have the correct order
+
 ## [0.5.14] - 2021-09-08
 
 ### Added

--- a/plume/src/main/kotlin/io/github/plume/oss/passes/graph/BaseCPGPass.kt
+++ b/plume/src/main/kotlin/io/github/plume/oss/passes/graph/BaseCPGPass.kt
@@ -15,7 +15,6 @@
  */
 package io.github.plume.oss.passes.graph
 
-import io.github.plume.oss.domain.mappers.ListMapper
 import io.github.plume.oss.domain.model.DeltaGraph
 import io.github.plume.oss.store.LocalCache
 import io.github.plume.oss.store.PlumeStorage
@@ -472,7 +471,7 @@ class BaseCPGPass(private val g: BriefUnitGraph) {
                     .argumentIndex(i)
                     .lineNumber(Option.apply(tgt.javaSourceStartLineNumber))
                     .columnNumber(Option.apply(tgt.javaSourceStartColumnNumber))
-                    .order(childIdx)
+                    .order(i)
                 builder.addEdge(switchVertex, tgtV, AST)
                 addToStore(unit, tgtV)
             }
@@ -507,7 +506,7 @@ class BaseCPGPass(private val g: BriefUnitGraph) {
                     .argumentIndex(lookupValue)
                     .lineNumber(Option.apply(tgt.javaSourceStartLineNumber))
                     .columnNumber(Option.apply(tgt.javaSourceStartColumnNumber))
-                    .order(childIdx)
+                    .order(lookupValue)
                 builder.addEdge(switchVertex, tgtV, AST)
                 addToStore(unit, tgtV)
             }


### PR DESCRIPTION
### Fixed

- `TableSwitchStmt` jump targets now have the correct order

### Related issues:

None

### Reviewer

@DavidBakerEffendi
