### PR TITLE
Removed unnecessary use of Log4j2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Removed unnecessary use of Log4j2
+
 ## [0.6.2] - 2021-10-07
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 kotlinVersion=1.4.21
 kotlinxVersion=1.4.2
 
-log4jVersion=2.15.0
 slf4jVersion=1.7.30
 progressBarVersion=0.9.1
 gremlinVersion=3.4.10

--- a/plume/build.gradle
+++ b/plume/build.gradle
@@ -35,9 +35,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxVersion"
 
     // Logging
-    implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     implementation "org.slf4j:jul-to-slf4j:$slf4jVersion" // JUL bridge
     implementation "org.slf4j:jcl-over-slf4j:$slf4jVersion" // Apache Commons Logging (JCL) bridge
     implementation "org.slf4j:log4j-over-slf4j:$slf4jVersion" // log4j1.2 bridge


### PR DESCRIPTION
### Fixed

- Removed unnecessary use of Log4j2

### Related issues:

In response to the [following vulnerability](https://www.randori.com/blog/cve-2021-44228/)

### Reviewer

@DavidBakerEffendi
