### PR TITLE
Fixed bug in GremlinDriver::propertyFromNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] - 2022-01-04
+
+### Fixed
+
+- `GremlinDriver` now handles nodes that do not include properties specified
+  under `GremlinDriver::propertyFromNodes`
+
 ## [1.0.0] - 2022-01-04
 
 ### Changed

--- a/src/main/scala/com/github/plume/oss/drivers/GremlinDriver.scala
+++ b/src/main/scala/com/github/plume/oss/drivers/GremlinDriver.scala
@@ -8,7 +8,7 @@ import io.shiftleft.proto.cpg.Cpg.DispatchTypes
 import org.apache.commons.configuration.BaseConfiguration
 import org.apache.tinkerpop.gremlin.process.traversal.P
 import org.apache.tinkerpop.gremlin.process.traversal.P.{neq, within}
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.has
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.{coalesce, constant, has, values}
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.{
   GraphTraversal,
   GraphTraversalSource,
@@ -205,10 +205,10 @@ abstract class GremlinDriver(txMax: Int = 50) extends IDriver {
         .hasLabel(nodeType)
         .project[Any](T.id.toString, keys: _*)
         .by(T.id)
-      keys.foreach(k => ptr = ptr.by(k))
+      keys.foreach(k => ptr = ptr.by(coalesce(values(k), constant("NULL"))))
       ptr.asScala
         .map(_.asScala.map { case (k, v) =>
-          if (v == null)
+          if (v == "NULL")
             k -> IDriver.getPropertyDefault(k)
           else
             k -> v

--- a/src/test/scala/com/github/plume/oss/testfixtures/PlumeDriverFixture.scala
+++ b/src/test/scala/com/github/plume/oss/testfixtures/PlumeDriverFixture.scala
@@ -37,7 +37,7 @@ class PlumeDriverFixture(val driver: IDriver)
     val adg =
       DiffGraph.Applier.applyDiff(diffGraph.build(), cpg.graph, undoable = false, Option(keyPool))
     driver.bulkTx(adg)
-    val List(m: Map[String, Any]) = driver.propertyFromNodes(METHOD, NAME, ORDER)
+    val List(m: Map[String, Any]) = driver.propertyFromNodes(METHOD, NAME, ORDER, DYNAMIC_TYPE_HINT_FULL_NAME)
     m.get(NAME) shouldBe Some("foo")
     m.get(ORDER) shouldBe Some(1)
     val List(b: Map[String, Any]) = driver.propertyFromNodes(BLOCK, ORDER)


### PR DESCRIPTION
### Fixed

- `GremlinDriver` now handles nodes that do not include properties specified
  under `GremlinDriver::propertyFromNodes`

### Related issues:

None

### Reviewer

@DavidBakerEffendi
