### PR TITLE
Parameters have Eval Strategies and this Parameters are Added in Dynamic Calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Method parameters now have correct evaluation strategies
+
 ### Fixed
 
 - Fixed performance issues in Gremlin drivers related to not re-using traversal objects.
+- Fixed instance in methods where `this` parameter was not passed through on dynamic calls.
 
 ## [1.0.12] - 2022-02-16
 

--- a/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
+++ b/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
@@ -161,9 +161,12 @@ class PlumeAstCreator(filename: String, global: Global) {
           case Failure(_)    => methodDeclaration.retrieveActiveBody()
           case Success(body) => body
         }
-        val parameterAsts = withOrder(methodBody.getParameterLocals) { (p, order) =>
-          astForParameter(p, order, methodDeclaration)
-        }
+        val parameterAsts =
+          Seq(createThisNode(methodDeclaration, NewMethodParameterIn())) ++ withOrder(
+            methodBody.getParameterLocals
+          ) { (p, order) =>
+            astForParameter(p, order, methodDeclaration)
+          }
         Ast(methodNode)
           .withChildren(parameterAsts)
           .withChild(astForMethodBody(methodBody, lastOrder))
@@ -189,6 +192,15 @@ class PlumeAstCreator(filename: String, global: Global) {
     }
   }
 
+  private def getEvaluationStrategy(typ: soot.Type): String =
+    typ match {
+      case _: PrimType    => EvaluationStrategies.BY_VALUE
+      case _: VoidType    => EvaluationStrategies.BY_VALUE
+      case _: NullType    => EvaluationStrategies.BY_VALUE
+      case _: RefLikeType => EvaluationStrategies.BY_REFERENCE
+      case _              => EvaluationStrategies.BY_SHARING
+    }
+
   private def astForParameter(
       parameter: soot.Local,
       childNum: Int,
@@ -202,6 +214,7 @@ class PlumeAstCreator(filename: String, global: Global) {
       .order(childNum)
       .lineNumber(line(methodDeclaration))
       .columnNumber(column(methodDeclaration))
+      .evaluationStrategy(getEvaluationStrategy(parameter.getType))
     Ast(parameterNode)
   }
 
@@ -367,7 +380,7 @@ class PlumeAstCreator(filename: String, global: Global) {
     val signature =
       s"${method.getReturnType.toQuotedString}(${(for (i <- 0 until method.getParameterCount)
         yield method.getParameterType(i).toQuotedString).mkString(",")})"
-    val thisAsts = Seq(createThisNode(invokeExpr.getMethod))
+    val thisAsts = Seq(createThisNode(invokeExpr.getMethod, NewIdentifier()))
 
     val callNode = NewCall()
       .name(method.getName)
@@ -470,15 +483,25 @@ class PlumeAstCreator(filename: String, global: Global) {
     )
   }
 
-  private def createThisNode(method: SootMethod): Ast = {
+  private def createThisNode(method: SootMethod, builder: NewNode): Ast = {
     if (!method.isStatic) {
       Ast(
-        NewIdentifier()
-          .name("this")
-          .code("this")
-          .typeFullName(registerType(method.getDeclaringClass.getType.toQuotedString))
-          .order(0)
-          .argumentIndex(0)
+        builder match {
+          case x: NewIdentifier =>
+            x.name("this")
+              .code("this")
+              .typeFullName(registerType(method.getDeclaringClass.getType.toQuotedString))
+              .order(0)
+              .argumentIndex(0)
+          case x: NewMethodParameterIn =>
+            x.name("this")
+              .code("this")
+              .lineNumber(line(method))
+              .typeFullName(registerType(method.getDeclaringClass.getType.toQuotedString))
+              .order(0)
+              .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+          case x => x
+        }
       )
     } else {
       Ast()

--- a/src/test/scala/com/github/plume/oss/DiffTests.scala
+++ b/src/test/scala/com/github/plume/oss/DiffTests.scala
@@ -66,7 +66,7 @@ class DiffTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     driver.propertyFromNodes(NodeTypes.METHOD).size shouldBe 7
     driver.propertyFromNodes(NodeTypes.TYPE, PropertyNames.FULL_NAME).size shouldBe 7
     driver.propertyFromNodes(NodeTypes.NAMESPACE_BLOCK, PropertyNames.FULL_NAME).size shouldBe 3
-    driver.propertyFromNodes(NodeTypes.METHOD_PARAMETER_IN, PropertyNames.FULL_NAME).size shouldBe 7
+    driver.propertyFromNodes(NodeTypes.METHOD_PARAMETER_IN, PropertyNames.FULL_NAME).size shouldBe 9
     driver.propertyFromNodes(NodeTypes.LOCAL, PropertyNames.FULL_NAME).size shouldBe 7
 
     val List(barM, fooM) = driver
@@ -97,7 +97,7 @@ class DiffTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     driver.propertyFromNodes(NodeTypes.METHOD).size shouldBe 7
     driver.propertyFromNodes(NodeTypes.TYPE, PropertyNames.FULL_NAME).size shouldBe 7
     driver.propertyFromNodes(NodeTypes.NAMESPACE_BLOCK, PropertyNames.FULL_NAME).size shouldBe 3
-    driver.propertyFromNodes(NodeTypes.METHOD_PARAMETER_IN, PropertyNames.FULL_NAME).size shouldBe 7
+    driver.propertyFromNodes(NodeTypes.METHOD_PARAMETER_IN, PropertyNames.FULL_NAME).size shouldBe 9
     driver.propertyFromNodes(NodeTypes.LOCAL, PropertyNames.FULL_NAME).size shouldBe 7
 
     val List(barM, fooM) = driver

--- a/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
@@ -46,7 +46,7 @@ class DataFlowTests extends Jimple2CpgFixture {
 
   "should find that System.out.println in sink is reached by both x parameters" in {
     val cpg = CPG(driver.cpg.graph)
-    val List(fooX: MethodParameterIn, sinkX: MethodParameterIn) =
+    val List(sinkX: MethodParameterIn, fooX: MethodParameterIn) =
       driver.nodesReachableBy(cpg.parameter("x"), cpg.call("println"))
     fooX.name shouldBe "x"
     fooX.method.name shouldBe "foo"

--- a/src/test/scala/com/github/plume/oss/querying/MethodParameterTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/MethodParameterTests.scala
@@ -1,6 +1,7 @@
 package com.github.plume.oss.querying
 
 import com.github.plume.oss.testfixtures.Jimple2CpgFixture
+import io.shiftleft.codepropertygraph.generated.EvaluationStrategies
 import io.shiftleft.semanticcpg.language._
 
 class MethodParameterTests extends Jimple2CpgFixture {
@@ -8,14 +9,22 @@ class MethodParameterTests extends Jimple2CpgFixture {
   override val code: String =
     """package a;
       |class Foo {
-      | int foo(int param1, int param2) {
+      | int foo(int param1, Object param2) {
       |  return 0;
       | }
       |}
       """.stripMargin
 
-  "should return exactly two parameters with correct fields" in {
-    cpg.parameter.filter(_.method.name == "foo").name.toSet shouldBe Set("param1", "param2")
+  "should return exactly three parameters with correct fields" in {
+    cpg.parameter.filter(_.method.name == "foo").name.toSet shouldBe Set("this", "param1", "param2")
+
+    val List(t) = cpg.parameter.filter(_.method.name == "foo").name("this").l
+    t.code shouldBe "this"
+    t.typeFullName shouldBe "a.Foo"
+    t.lineNumber shouldBe Some(3)
+    t.columnNumber shouldBe None
+    t.order shouldBe 0
+    t.evaluationStrategy shouldBe EvaluationStrategies.BY_SHARING
 
     val List(x) = cpg.parameter.filter(_.method.name == "foo").name("param1").l
     x.code shouldBe "int param1"
@@ -23,13 +32,15 @@ class MethodParameterTests extends Jimple2CpgFixture {
     x.lineNumber shouldBe Some(3)
     x.columnNumber shouldBe Some(-1)
     x.order shouldBe 1
+    x.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE
 
     val List(y) = cpg.parameter.filter(_.method.name == "foo").name("param2").l
-    y.code shouldBe "int param2"
-    y.typeFullName shouldBe "int"
+    y.code shouldBe "java.lang.Object param2"
+    y.typeFullName shouldBe "java.lang.Object"
     y.lineNumber shouldBe Some(3)
     y.columnNumber shouldBe Some(-1)
     y.order shouldBe 2
+    y.evaluationStrategy shouldBe EvaluationStrategies.BY_REFERENCE
   }
 
   "should allow traversing from parameter to method" in {

--- a/src/test/scala/com/github/plume/oss/querying/MethodTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/MethodTests.scala
@@ -34,7 +34,7 @@ class MethodTests extends Jimple2CpgFixture {
   //  }
 
   "should allow traversing to parameters" in {
-    cpg.method.name("foo").parameter.name.toSet shouldBe Set("param1", "param2")
+    cpg.method.name("foo").parameter.name.toSet shouldBe Set("this", "param1", "param2")
   }
 
   "should allow traversing to methodReturn" in {


### PR DESCRIPTION
### Added

- Method parameters now have correct evaluation strategies

### Fixed

- Fixed instance in methods where `this` parameter was not passed through on dynamic calls.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
