### PR TITLE
Constructor Tests and Method Modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Methods now have modifier nodes.
+- Using `<operator>.alloc` for initial `new` assignments to objects and this has been added to `default.semantics`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Methods now have modifier nodes.
+
+### Changed
+
+- Made constructors a bit friendlier to work with and they now have `this` parameters.
+
 ## [1.0.14] - 2022-02-22
 
 ### Fixed

--- a/src/main/resources/default.semantics
+++ b/src/main/resources/default.semantics
@@ -2,6 +2,7 @@
 # 1->-1 first parameter mapped to return value (-1)
 "<operator>.addition" 1->-1 2->-1
 "<operator>.addressOf" 1->-1
+"<operator>.alloc" 1->-1 2->-1
 "<operator>.assignment" 2->1
 "<operator>.assignmentAnd" 2->1 1->1
 "<operator>.assignmentArithmeticShiftRight" 2->1 1->1

--- a/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
+++ b/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
@@ -182,6 +182,7 @@ class PlumeAstCreator(filename: String, global: Global) {
           e
         )
         Ast(methodNode)
+          .withChildren(astsForModifiers(methodDeclaration))
           .withChild(astForMethodReturn(methodDeclaration))
     } finally {
       // Join all targets with CFG edges - this seems to work from what is seen on DotFiles

--- a/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
+++ b/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
@@ -830,7 +830,7 @@ class PlumeAstCreator(filename: String, global: Global) {
       .withArgEdges(rootNode, args.flatMap(_.root))
   }
 
-  def astsForModifiers(methodDeclaration: SootMethod): Seq[Ast] = {
+  private def astsForModifiers(methodDeclaration: SootMethod): Seq[Ast] = {
     Seq(
       if (methodDeclaration.isStatic) Some(ModifierTypes.STATIC) else None,
       if (methodDeclaration.isPublic) Some(ModifierTypes.PUBLIC) else None,
@@ -867,7 +867,7 @@ class PlumeAstCreator(filename: String, global: Global) {
     val code = if (!methodDeclaration.isConstructor) {
       s"${methodDeclaration.getReturnType.toQuotedString} ${methodDeclaration.getName}${paramListSignature(methodDeclaration, withParams = true)}"
     } else {
-      s"public ${typeDecl.getClassName}${paramListSignature(methodDeclaration, withParams = true)}"
+      s"${typeDecl.getClassName}${paramListSignature(methodDeclaration, withParams = true)}"
     }
     NewMethod()
       .name(methodDeclaration.getName)

--- a/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
+++ b/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
@@ -155,19 +155,24 @@ class PlumeAstCreator(filename: String, global: Global) {
     try {
       if (!methodDeclaration.isConcrete) {
         Ast(methodNode)
+          .withChildren(astsForModifiers(methodDeclaration))
           .withChild(astForMethodReturn(methodDeclaration))
       } else {
         val methodBody = Try(methodDeclaration.getActiveBody) match {
           case Failure(_)    => methodDeclaration.retrieveActiveBody()
           case Success(body) => body
         }
+        if (methodDeclaration.toString.contains("test1"))
+          println(methodBody)
         val parameterAsts =
           Seq(createThisNode(methodDeclaration, NewMethodParameterIn())) ++ withOrder(
             methodBody.getParameterLocals
           ) { (p, order) =>
             astForParameter(p, order, methodDeclaration)
           }
+
         Ast(methodNode)
+          .withChildren(astsForModifiers(methodDeclaration))
           .withChildren(parameterAsts)
           .withChild(astForMethodBody(methodBody, lastOrder))
           .withChild(astForMethodReturn(methodDeclaration))
@@ -375,9 +380,10 @@ class PlumeAstCreator(filename: String, global: Global) {
 
   private def astForInvokeExpr(invokeExpr: InvokeExpr, order: Int, parentUnit: soot.Unit): Ast = {
     val dispatchType = invokeExpr match {
-      case _: DynamicInvokeExpr  => DispatchTypes.DYNAMIC_DISPATCH
-      case _: InstanceInvokeExpr => DispatchTypes.DYNAMIC_DISPATCH
-      case _                     => DispatchTypes.STATIC_DISPATCH
+      case x if x.getMethod.isConstructor => DispatchTypes.STATIC_DISPATCH
+      case _: DynamicInvokeExpr           => DispatchTypes.DYNAMIC_DISPATCH
+      case _: InstanceInvokeExpr          => DispatchTypes.DYNAMIC_DISPATCH
+      case _                              => DispatchTypes.STATIC_DISPATCH
     }
     val method = invokeExpr.getMethod
     val signature =
@@ -385,15 +391,25 @@ class PlumeAstCreator(filename: String, global: Global) {
         yield method.getParameterType(i).toQuotedString).mkString(",")})"
     val thisAsts = Seq(createThisNode(invokeExpr.getMethod, NewIdentifier()))
 
+    val methodName =
+      if (method.isConstructor)
+        registerType(method.getDeclaringClass.getType.getClassName)
+      else
+        method.getName
+
+    val callType =
+      if (invokeExpr.getMethod.isConstructor) "void"
+      else registerType(method.getDeclaringClass.getType.toQuotedString)
+
     val callNode = NewCall()
       .name(method.getName)
-      .code(s"${method.getName}(${invokeExpr.getArgs.asScala.mkString(", ")})")
+      .code(s"$methodName(${invokeExpr.getArgs.asScala.mkString(", ")})")
       .dispatchType(dispatchType)
       .order(order)
       .argumentIndex(order)
       .methodFullName(s"${method.getDeclaringClass.toString}.${method.getName}:$signature")
       .signature(signature)
-      .typeFullName(registerType(method.getDeclaringClass.getType.toQuotedString))
+      .typeFullName(callType)
       .lineNumber(line(parentUnit))
       .columnNumber(column(parentUnit))
 
@@ -418,10 +434,14 @@ class PlumeAstCreator(filename: String, global: Global) {
       case u: NewMultiArrayExpr =>
         astForArrayInitializeExpr(x, u.getSizes.asScala, order, parentUnit)
       case _ =>
+        val parentType = registerType(x.getType.toQuotedString)
         Ast(
-          NewUnknown()
-            .typeFullName(registerType(x.getType.toQuotedString))
-            .code("new")
+          NewCall()
+            .name("<operator>.alloc")
+            .methodFullName("<operator>.alloc")
+            .typeFullName(parentType)
+            .code(s"new ${x.getType}")
+            .dispatchType(DispatchTypes.STATIC_DISPATCH)
             .order(order)
             .argumentIndex(order)
             .lineNumber(line(parentUnit))
@@ -481,28 +501,32 @@ class PlumeAstCreator(filename: String, global: Global) {
         .name("this")
         .code("this")
         .typeFullName(registerType(method.getType.toQuotedString))
+        .dynamicTypeHintFullName(Seq(method.getType.toQuotedString))
         .order(0)
         .argumentIndex(0)
     )
   }
 
   private def createThisNode(method: SootMethod, builder: NewNode): Ast = {
-    if (!method.isStatic) {
+    if (!method.isStatic || method.isConstructor) {
+      val parentType = registerType(method.getDeclaringClass.getType.toQuotedString)
       Ast(
         builder match {
           case x: NewIdentifier =>
             x.name("this")
               .code("this")
-              .typeFullName(registerType(method.getDeclaringClass.getType.toQuotedString))
+              .typeFullName(parentType)
               .order(0)
               .argumentIndex(0)
+              .dynamicTypeHintFullName(Seq(parentType))
           case x: NewMethodParameterIn =>
             x.name("this")
               .code("this")
               .lineNumber(line(method))
-              .typeFullName(registerType(method.getDeclaringClass.getType.toQuotedString))
+              .typeFullName(parentType)
               .order(0)
               .evaluationStrategy(EvaluationStrategies.BY_SHARING)
+              .dynamicTypeHintFullName(Seq(parentType))
           case x => x
         }
       )
@@ -807,6 +831,23 @@ class PlumeAstCreator(filename: String, global: Global) {
       .withArgEdges(rootNode, args.flatMap(_.root))
   }
 
+  def astsForModifiers(methodDeclaration: SootMethod): Seq[Ast] = {
+    Seq(
+      if (methodDeclaration.isStatic) Some(ModifierTypes.STATIC) else None,
+      if (methodDeclaration.isPublic) Some(ModifierTypes.PUBLIC) else None,
+      if (methodDeclaration.isProtected) Some(ModifierTypes.PROTECTED) else None,
+      if (methodDeclaration.isPrivate) Some(ModifierTypes.PRIVATE) else None,
+      if (methodDeclaration.isAbstract) Some(ModifierTypes.ABSTRACT) else None,
+      if (methodDeclaration.isConstructor) Some(ModifierTypes.CONSTRUCTOR) else None,
+      if (!methodDeclaration.isFinal && !methodDeclaration.isStatic && methodDeclaration.isPublic)
+        Some(ModifierTypes.VIRTUAL)
+      else None,
+      if (methodDeclaration.isSynchronized) Some("SYNCHRONIZED") else None
+    ).flatten.map { modifier =>
+      Ast(NewModifier().modifierType(modifier).code(modifier.toLowerCase))
+    }
+  }
+
   private def astForMethodReturn(methodDeclaration: SootMethod): Ast = {
     val typeFullName = registerType(methodDeclaration.getReturnType.toQuotedString)
     val methodReturnNode =
@@ -824,10 +865,15 @@ class PlumeAstCreator(filename: String, global: Global) {
       childNum: Int
   ) = {
     val fullName = methodFullName(typeDecl, methodDeclaration)
-    val code =
+    val name =
+      if (!methodDeclaration.isConstructor) methodDeclaration.getName else typeDecl.getClassName
+    val code = if (!methodDeclaration.isConstructor) {
       s"${methodDeclaration.getReturnType.toQuotedString} ${methodDeclaration.getName}${paramListSignature(methodDeclaration, withParams = true)}"
+    } else {
+      s"public ${typeDecl.getClassName}${paramListSignature(methodDeclaration, withParams = true)}"
+    }
     NewMethod()
-      .name(methodDeclaration.getName)
+      .name(name)
       .fullName(fullName)
       .code(code)
       .signature(

--- a/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
+++ b/src/main/scala/com/github/plume/oss/passes/parallel/PlumeAstCreator.scala
@@ -162,8 +162,6 @@ class PlumeAstCreator(filename: String, global: Global) {
           case Failure(_)    => methodDeclaration.retrieveActiveBody()
           case Success(body) => body
         }
-        if (methodDeclaration.toString.contains("test1"))
-          println(methodBody)
         val parameterAsts =
           Seq(createThisNode(methodDeclaration, NewMethodParameterIn())) ++ withOrder(
             methodBody.getParameterLocals
@@ -865,15 +863,13 @@ class PlumeAstCreator(filename: String, global: Global) {
       childNum: Int
   ) = {
     val fullName = methodFullName(typeDecl, methodDeclaration)
-    val name =
-      if (!methodDeclaration.isConstructor) methodDeclaration.getName else typeDecl.getClassName
     val code = if (!methodDeclaration.isConstructor) {
       s"${methodDeclaration.getReturnType.toQuotedString} ${methodDeclaration.getName}${paramListSignature(methodDeclaration, withParams = true)}"
     } else {
       s"public ${typeDecl.getClassName}${paramListSignature(methodDeclaration, withParams = true)}"
     }
     NewMethod()
-      .name(name)
+      .name(methodDeclaration.getName)
       .fullName(fullName)
       .code(code)
       .signature(

--- a/src/test/resources/default.semantics
+++ b/src/test/resources/default.semantics
@@ -2,6 +2,7 @@
 # 1->-1 first parameter mapped to return value (-1)
 "<operator>.addition" 1->-1 2->-1
 "<operator>.addressOf" 1->-1
+"<operator>.alloc" 1->-1 2->-1
 "<operator>.assignment" 2->1
 "<operator>.assignmentAnd" 2->1 1->1
 "<operator>.assignmentArithmeticShiftRight" 2->1 1->1

--- a/src/test/scala/com/github/plume/oss/querying/ConstructorInvocationTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/ConstructorInvocationTests.scala
@@ -57,7 +57,7 @@ class ConstructorInvocationTests extends Jimple2CpgFixture {
       case List(cons: Method) =>
         cons.fullName shouldBe "Foo.<init>:void(int)"
         cons.signature shouldBe "void(int)"
-        cons.code shouldBe "public Foo(int x)"
+        cons.code shouldBe "Foo(int x)"
         cons.parameter.size shouldBe 2
         val objParam = cons.parameter.index(0).head
         objParam.name shouldBe "this"

--- a/src/test/scala/com/github/plume/oss/querying/ConstructorInvocationTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/ConstructorInvocationTests.scala
@@ -76,14 +76,14 @@ class ConstructorInvocationTests extends Jimple2CpgFixture {
       case List(cons1: Method, cons2: Method) =>
         cons1.fullName shouldBe "Bar.<init>:void(int)"
         cons1.signature shouldBe "void(int)"
-        cons1.code shouldBe "public Bar(int x)"
+        cons1.code shouldBe "Bar(int x)"
         cons1.parameter.size shouldBe 2
         cons1.parameter.index(0).head.name shouldBe "this"
         cons1.parameter.index(1).head.name shouldBe "x"
 
         cons2.fullName shouldBe "Bar.<init>:void(int,int)"
         cons2.signature shouldBe "void(int,int)"
-        cons2.code shouldBe "public Bar(int x, int y)"
+        cons2.code shouldBe "Bar(int x, int y)"
         cons2.parameter.size shouldBe 3
         cons2.parameter.index(0).head.name shouldBe "this"
         cons2.parameter.index(1).head.name shouldBe "x"

--- a/src/test/scala/com/github/plume/oss/querying/ConstructorInvocationTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/ConstructorInvocationTests.scala
@@ -1,0 +1,275 @@
+package com.github.plume.oss.querying
+
+import com.github.plume.oss.testfixtures.Jimple2CpgFixture
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Block,
+  Call,
+  Identifier,
+  Literal,
+  Local,
+  Method,
+  Return
+}
+import io.shiftleft.proto.cpg.Cpg.DispatchTypes
+import io.shiftleft.semanticcpg.language._
+
+class ConstructorInvocationTests extends Jimple2CpgFixture {
+
+  override val code: String =
+    """
+      |class Foo {
+      |  int x;
+      |
+      |  public Foo(int x) {
+      |    this.x = x;
+      |  }
+      |
+      |  public int getValue() {
+      |    return x;
+      |  }
+      |}
+      |
+      |class Bar extends Foo {
+      |  public Bar(int x) {
+      |    super(x);
+      |  }
+      |
+      |  public Bar(int x, int y) {
+      |    this(x + y);
+      |  }
+      |
+      |  public static Bar id(Bar b) {
+      |    return b;
+      |  }
+      |
+      |  public static void test1() {
+      |    Bar b = new Bar(4, 2);
+      |  }
+      |
+      |  public static void test2(Bar b) {
+      |    b = new Bar(4, 2);
+      |  }
+      |
+      |  public static void test3(Bar[] bs) {
+      |    bs[0] = new Bar(42);
+      |  }
+      |}
+      |""".stripMargin
+
+  "it should create correct method nodes for constructors" in {
+    cpg.method.name("<init>").where(_.fullName("^Foo.*")).l match {
+      case List(cons: Method) =>
+        cons.fullName shouldBe "Foo.<init>:void(int)"
+        cons.signature shouldBe "void(int)"
+        cons.code shouldBe "public Foo(int x)"
+        cons.parameter.size shouldBe 2
+        val objParam = cons.parameter.index(0).head
+        objParam.name shouldBe "this"
+        objParam.typeFullName shouldBe "Foo"
+        objParam.dynamicTypeHintFullName shouldBe Seq("Foo")
+        val otherParam = cons.parameter.index(1).head
+        otherParam.name shouldBe "x"
+        otherParam.typeFullName shouldBe "int"
+        otherParam.dynamicTypeHintFullName shouldBe Seq()
+
+      case res =>
+        fail(s"Expected single Foo constructor, but got $res")
+    }
+
+    cpg.method.name("<init>").where(_.fullName("^Bar.*")).l match {
+      case List(cons1: Method, cons2: Method) =>
+        cons1.fullName shouldBe "Bar.<init>:void(int)"
+        cons1.signature shouldBe "void(int)"
+        cons1.code shouldBe "public Bar(int x)"
+        cons1.parameter.size shouldBe 2
+        cons1.parameter.index(0).head.name shouldBe "this"
+        cons1.parameter.index(1).head.name shouldBe "x"
+
+        cons2.fullName shouldBe "Bar.<init>:void(int,int)"
+        cons2.signature shouldBe "void(int,int)"
+        cons2.code shouldBe "public Bar(int x, int y)"
+        cons2.parameter.size shouldBe 3
+        cons2.parameter.index(0).head.name shouldBe "this"
+        cons2.parameter.index(1).head.name shouldBe "x"
+        cons2.parameter.index(2).head.name shouldBe "y"
+
+      case res =>
+        fail(s"Expected 2 Bar constructors, but got $res")
+    }
+  }
+
+  "it should create joint `alloc` and `init` calls for a constructor invocation in a vardecl" in {
+    cpg.typeDecl.name("Bar").method.name("test1").l match {
+      case List(method) =>
+        val List(_: Local, assign: Call, init: Call, _: Local, _: Call, _: Return) =
+          method.astChildren.isBlock.astChildren.l
+
+        assign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        assign.name shouldBe Operators.assignment
+        val alloc = assign.argument(2).asInstanceOf[Call]
+        alloc.name shouldBe "<operator>.alloc"
+        alloc.code shouldBe "new Bar"
+        alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        alloc.methodFullName shouldBe "<operator>.alloc"
+        alloc.typeFullName shouldBe "Bar"
+        alloc.argument.size shouldBe 0
+
+        init.name shouldBe "<init>"
+        init.methodFullName shouldBe "Bar.<init>:void(int,int)"
+        init.callOut.head.fullName shouldBe "Bar.<init>:void(int,int)"
+        init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        init.typeFullName shouldBe "void"
+        init.signature shouldBe "void(int,int)"
+        init.code shouldBe "Bar(4, 2)"
+
+        init.argument.size shouldBe 3
+        val List(obj: Identifier, initArg1: Literal, initArg2: Literal) = init.argument.l
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+        obj.name shouldBe "this"
+        obj.typeFullName shouldBe "Bar"
+        obj.code shouldBe "this"
+        initArg1.code shouldBe "4"
+        initArg2.code shouldBe "2"
+
+      case res => fail(s"Expected main method in Bar but found $res")
+    }
+  }
+
+  "it should create joint `alloc` and `init` calls for a constructor invocation in an assignment" in {
+    cpg.typeDecl.name("Bar").method.name("test2").l match {
+      case List(method) =>
+        val List(
+          _: Local,
+          paramAssign: Call,
+          _: Local,
+          assign: Call,
+          init: Call,
+          _: Local,
+          _: Call,
+          _: Return
+        ) = method.astChildren.isBlock.astChildren.l
+
+        assign.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        assign.name shouldBe Operators.assignment
+        val alloc = assign.argument(2).asInstanceOf[Call]
+        alloc.name shouldBe "<operator>.alloc"
+        alloc.code shouldBe "new Bar"
+        alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        alloc.methodFullName shouldBe "<operator>.alloc"
+        alloc.typeFullName shouldBe "Bar"
+        alloc.argument.size shouldBe 0
+
+        init.name shouldBe "<init>"
+        init.methodFullName shouldBe "Bar.<init>:void(int,int)"
+        init.callOut.head.fullName shouldBe "Bar.<init>:void(int,int)"
+        init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        init.typeFullName shouldBe "void"
+        init.signature shouldBe "void(int,int)"
+        init.code shouldBe "Bar(4, 2)"
+
+        init.argument.size shouldBe 3
+        val List(obj: Identifier, initArg1: Literal, initArg2: Literal) = init.argument.l
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+        obj.name shouldBe "this"
+        obj.typeFullName shouldBe "Bar"
+        obj.code shouldBe "this"
+        initArg1.code shouldBe "4"
+        initArg2.code shouldBe "2"
+
+      case res => fail(s"Expected main method in Bar but found $res")
+    }
+  }
+
+  "it should create `alloc` and `init` calls in a block for complex assignments" in {
+    // TODO
+    cpg.typeDecl.name("Bar").method.name("test3").l match {
+      case List(method) =>
+        val assignCall                                      = method.call.nameExact("<operator>.assignment").head
+        val consBlock                                       = assignCall.argument(2).asInstanceOf[Block]
+        val List(assign: Call, init: Call, ret: Identifier) = consBlock.astChildren.l
+
+        val List(temp: Identifier, alloc: Call) = assign.argument.l
+        temp.name shouldBe "$obj3"
+        temp.typeFullName shouldBe "Bar"
+        temp.order shouldBe 1
+        temp.argumentIndex shouldBe 1
+        temp.code shouldBe "$obj3"
+
+        alloc.name shouldBe "<operator>.alloc"
+        alloc.methodFullName shouldBe "<operator>.alloc"
+        alloc.order shouldBe 2
+        alloc.argumentIndex shouldBe 2
+        alloc.code shouldBe "new Bar(42)"
+        alloc.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        alloc.typeFullName shouldBe "Bar"
+        alloc.argument.size shouldBe 0
+
+        init.name shouldBe "<init>"
+        init.methodFullName shouldBe "Bar.<init>:void(int)"
+        init.callOut.head.fullName shouldBe "Bar.<init>:void(int)"
+        init.signature shouldBe "void(int)"
+        init.code shouldBe "new Bar(42)"
+        init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+
+        init.argument.size shouldBe 2
+        val List(obj: Identifier, initArg1: Literal) = init.argument.l
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+        obj.name shouldBe "$obj3"
+        obj.typeFullName shouldBe "Bar"
+
+        initArg1.code shouldBe "42"
+
+      case res => fail(s"Expected method test3 in Bar but found $res")
+    }
+  }
+
+  "it should create only `init` call for direct invocation using `this`" in {
+    cpg.typeDecl.name("Bar").method.fullNameExact("Bar.<init>:void(int,int)").l match {
+      case List(method) =>
+        val List(init: Call) = method.astChildren.isBlock.astChildren.l
+        init.name shouldBe "<init>"
+        init.methodFullName shouldBe "Bar.<init>:void(int)"
+        init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        init.typeFullName shouldBe "void"
+        init.signature shouldBe "void(int)"
+
+        val List(obj: Identifier, initArg1: Call) = init.argument.l
+        obj.name shouldBe "this"
+        obj.order shouldBe 0
+        obj.argumentIndex shouldBe 0
+        obj.typeFullName shouldBe "Bar"
+
+        initArg1.code shouldBe "x + y"
+
+      case res => fail(s"Expected Bar constructor but found $res")
+    }
+  }
+
+  "it should create only `init` call for direct invocation using `super`" in {
+    cpg.typeDecl.name("Bar").method.fullNameExact("Bar.<init>:void(int)").l match {
+      case List(method) =>
+        val List(init: Call) = method.astChildren.isBlock.astChildren.l
+        init.name shouldBe "<init>"
+        init.methodFullName shouldBe "Foo.<init>:void(int)"
+        init.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH.toString
+        init.typeFullName shouldBe "void"
+        init.signature shouldBe "void(int)"
+
+        val List(obj: Identifier, initArg: Identifier) = init.argument.l
+        obj.name shouldBe "this"
+        obj.typeFullName shouldBe "Bar"
+        obj.argumentIndex shouldBe 0
+        obj.order shouldBe 0
+        obj.code shouldBe "this"
+
+        initArg.code shouldBe "x"
+
+      case res => fail(s"Expected Bar constructor but found $res")
+    }
+  }
+
+}


### PR DESCRIPTION
### Added

- Methods now have modifier nodes.
- Using `<operator>.alloc` for initial `new` assignments to objects and this has been added to `default.semantics`.

### Changed

- Made constructors a bit friendlier to work with and they now have `this` parameters.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
