### PR TITLE
Minor Soot + File Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- No longer set `deleteOnExit` for files in temp dir since they get cleaned via try-final call already.
+- Set Soot to non-application mode and non-whole program mode for efficiency.
+
 ## [1.0.20] - 2022-03-11
 
 ### Fixed

--- a/src/main/scala/com/github/plume/oss/Jimple2Cpg.scala
+++ b/src/main/scala/com/github/plume/oss/Jimple2Cpg.scala
@@ -197,8 +197,8 @@ class Jimple2Cpg {
     sourceFileNames
       .map(getQualifiedClassPath)
       .foreach { cp =>
-        Scene.v().addBasicClass(cp, SootClass.BODIES)
-        Scene.v().loadClassAndSupport(cp).setApplicationClass()
+        Scene.v().addBasicClass(cp)
+        Scene.v().loadClassAndSupport(cp)
       }
     Scene.v().loadNecessaryClasses()
   }

--- a/src/main/scala/com/github/plume/oss/Jimple2Cpg.scala
+++ b/src/main/scala/com/github/plume/oss/Jimple2Cpg.scala
@@ -200,9 +200,7 @@ class Jimple2Cpg {
         Scene.v().addBasicClass(cp, SootClass.BODIES)
         Scene.v().loadClassAndSupport(cp).setApplicationClass()
       }
-    Scene.v().loadDynamicClasses()
     Scene.v().loadNecessaryClasses()
-    Scene.v().addBasicClass("soot.dummy.InvokeDynamic", SootClass.SIGNATURES)
   }
 
   private def basePasses(
@@ -238,9 +236,10 @@ class Jimple2Cpg {
   ).collect { case pass: CpgPassBase with PlumeCpgPassBase => pass }
 
   private def configureSoot(): Unit = {
+    logger.info("Configuring Soot")
     // set application mode
-    Options.v().set_app(true)
-    Options.v().set_whole_program(true)
+    Options.v().set_app(false)
+    Options.v().set_whole_program(false)
     // make sure classpath is configured correctly
     Options.v().set_soot_classpath(ProgramHandlingUtil.TEMP_DIR.toString)
     Options.v().set_prepend_classpath(true)

--- a/src/main/scala/com/github/plume/oss/util/ProgramHandlingUtil.scala
+++ b/src/main/scala/com/github/plume/oss/util/ProgramHandlingUtil.scala
@@ -93,7 +93,6 @@ object ProgramHandlingUtil {
             Using.resource(zip.getInputStream(entry)) { input =>
               Files.copy(input, destFile.toPath)
             }
-            destFile.deleteOnExit()
             Option(destFile.getAbsolutePath)
           } catch {
             case e: Exception =>


### PR DESCRIPTION
### Fixed

- No longer set `deleteOnExit` for files in temp dir since they get cleaned via try-final call already.
- Set Soot to non-application mode and non-whole program mode for efficiency.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
