### PR TITLE
Better Temp Storage Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Delete the unpacking dir after clean and generating a new one as needed if a successive analysis occurs.
+- Making the reference DB `None` by default to avoid accidentally generating large amounts of stored graphs.
+
 ## [1.1.2] - 2022-03-16
 
 ### Added

--- a/src/main/scala/com/github/plume/oss/Jimple2Cpg.scala
+++ b/src/main/scala/com/github/plume/oss/Jimple2Cpg.scala
@@ -44,7 +44,7 @@ object Jimple2Cpg {
     * @return the correctly formatted class path.
     */
   def getQualifiedClassPath(filename: String): String = {
-    val codePath = ProgramHandlingUtil.TEMP_DIR
+    val codePath = ProgramHandlingUtil.getUnpackingDir
     val codeDir: String = if (codePath.toFile.isDirectory) {
       codePath.toAbsolutePath.normalize.toString
     } else {
@@ -68,7 +68,7 @@ class Jimple2Cpg {
   /** Creates a CPG from Jimple.
     *
     * @param rawSourceCodePath  The path to the Jimple code or code that can be transformed into Jimple.
-    * @param outputPath         The path to store the CPG. If `outputPath` is `None`, the CPG is created in-memory.
+    * @param referenceGraphOutputPath         The path to store the CPG. If `outputPath` is `None`, the CPG is created in-memory.
     * @param driver             The driver used to interact with the backend database.
     * @param sootOnlyBuild      (Experimental) Used to determine how many resources are used when only loading files
     *                           into Soot.
@@ -77,7 +77,7 @@ class Jimple2Cpg {
     */
   def createCpg(
       rawSourceCodePath: String,
-      outputPath: Option[String] = Option(JFile.createTempFile("plume-", ".odb").getAbsolutePath),
+      referenceGraphOutputPath: Option[String] = None,
       driver: IDriver = new OverflowDbDriver(),
       sootOnlyBuild: Boolean = false
   ): Cpg = PlumeStatistics.time(
@@ -96,7 +96,7 @@ class Jimple2Cpg {
         }
 
         configureSoot()
-        val cpg = newEmptyCpg(outputPath)
+        val cpg = newEmptyCpg(referenceGraphOutputPath)
 
         val metaDataKeyPool = new IncrementalKeyPool(1, 100, driver.idInterval(1, 100))
         val typesKeyPool    = new IncrementalKeyPool(101, 2_000_100, driver.idInterval(101, 2_000_100))
@@ -257,7 +257,7 @@ class Jimple2Cpg {
     Options.v().set_app(false)
     Options.v().set_whole_program(false)
     // make sure classpath is configured correctly
-    Options.v().set_soot_classpath(ProgramHandlingUtil.TEMP_DIR.toString)
+    Options.v().set_soot_classpath(ProgramHandlingUtil.getUnpackingDir.toAbsolutePath.toString)
     Options.v().set_prepend_classpath(true)
     // keep debugging info
     Options.v().set_keep_line_number(true)

--- a/src/test/scala/com/github/plume/oss/unpacking/JarUnpackingTests.scala
+++ b/src/test/scala/com/github/plume/oss/unpacking/JarUnpackingTests.scala
@@ -30,7 +30,7 @@ class JarUnpackingTests extends AnyWordSpec with Matchers with BeforeAndAfterAll
     Try(getClass.getResource("/unpacking")) match {
       case Success(x) =>
         val fs = File(x.getPath).toDirectory.walk.toSeq
-        val cs = File(ProgramHandlingUtil.TEMP_DIR.toString).toDirectory.walk.toSeq
+        val cs = File(ProgramHandlingUtil.getUnpackingDir.toString).toDirectory.walk.toSeq
         fs.filter(_.name.contains(".jar")).map(_.name).toList shouldBe List("HelloWorld.jar")
         cs.count(_.name.contains(".class")) shouldBe 0
       case Failure(x: Throwable) =>


### PR DESCRIPTION
### Changed

- Delete the unpacking dir after clean and generating a new one as needed if a successive analysis occurs.
- Making the reference DB `None` by default to avoid accidentally generating large amounts of stored graphs.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
