### PR TITLE
Added Export to GraphML for ODB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `OverflowDbDriver::exportAsGraphML` for writing the graph instance as an XML file.
+
 ## [1.1.5] - 2022-03-18
 
 ### Changed

--- a/src/main/scala/com/github/plume/oss/drivers/OverflowDbDriver.scala
+++ b/src/main/scala/com/github/plume/oss/drivers/OverflowDbDriver.scala
@@ -452,20 +452,21 @@ final case class OverflowDbDriver(
       osw.write("<graph id=\"G\" edgedefault=\"directed\">")
       // Write vertices
       g.nodes().foreach { (n: Node) =>
-        osw.write("<node id=\"" + n.id + "\"")
+        osw.write("<node id=\"" + n.id + "\">")
         osw.write("<data key=\"labelV\">" + n.label() + "</data>")
         serializeLists(n.propertiesMap().asScala.toMap).foreach { case (k, v) =>
           osw.write(
-            "<data key=\"" + k + "\">\"" + StringEscapeUtils.escapeXml(v.toString) + "\"</data>"
+            "<data key=\"" + k + "\">" + StringEscapeUtils.escapeXml(v.toString) + "</data>"
           )
         }
+        osw.write("</node>")
       }
       // Write edges
       g.edges().zipWithIndex.foreach { case (e: Edge, i: Int) =>
         osw.write("<edge id=\"" + i + "\" ")
         osw.write("source=\"" + e.outNode().id() + "\" ")
         osw.write("target=\"" + e.inNode().id() + "\">")
-        osw.write("<data key=\"labelE\">" + e.label() + "/data>")
+        osw.write("<data key=\"labelE\">" + e.label() + "</data>")
         osw.write("</edge>")
       }
       // Close graph tags


### PR DESCRIPTION
### Added

- `OverflowDbDriver::exportAsGraphML` for writing the graph instance as an XML file.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
