### PR TITLE
Added the ability to add sanitizer methods to reachableBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `OverflowDbDriver::nodesReachableBy` now has `sanitizers` parameter for method calls to filter paths out with.
+
 ## [1.1.9] - 2022-03-22
 
 ### Fixed

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ inThisBuild(
 )
 
 val cpgVersion         = "1.3.519"
-val joernVersion       = "1.1.637"
+val joernVersion       = "1.1.639"
 val sootVersion        = "4.3.0"
 val tinkerGraphVersion = "3.4.11"
 val neo4jVersion       = "4.4.3"

--- a/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
@@ -78,10 +78,10 @@ class DataFlowTests extends Jimple2CpgFixture {
     v2.last shouldBe ("bar", "$stack1.println(x)")
   }
 
-  "should find that System.out.println in baz is not reached if clean is set as a sanitizer" in {
+  "should find that parameters tainted by calls to 'taint' is not reached if falseClean is set as a sanitizer" in {
     val cpg = CPG(driver.cpg.graph)
 
-    def source = cpg.parameter("a")
+    def source = cpg.call("taint").argument
     def sink   = cpg.call("baz")
 
     val r1     = driver.nodesReachableBy(source, sink)

--- a/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
@@ -11,8 +11,7 @@ class DataFlowTests extends Jimple2CpgFixture {
   override val code: String =
     """
       |class Foo {
-      | public static int foo() {
-      |  int a = 1;
+      | public static int foo(int a) {
       |  taint(a);
       |  if (a < 10) {
       |    bar(a);

--- a/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
@@ -83,18 +83,11 @@ class DataFlowTests extends Jimple2CpgFixture {
 
     def source = cpg.parameter("a")
     def sink   = cpg.call("baz")
-    val r1     = driver.nodesReachableBy(source, sink)
 
+    val r1     = driver.nodesReachableBy(source, sink)
     r1.size shouldBe 1
 
-    val List(v1) = r1.map(r =>
-      r.path.map(x =>
-        (x.node.method.name, x.node.astParent.code, x.node.astParent.property("METHOD_FULL_NAME"))
-      )
-    )
-
     val r2 = driver.nodesReachableBy(source, sink, Set("Foo.falseClean:int(int)"))
-
     r2.size shouldBe 0
   }
 

--- a/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
+++ b/src/test/scala/com/github/plume/oss/querying/DataFlowTests.scala
@@ -11,47 +11,91 @@ class DataFlowTests extends Jimple2CpgFixture {
   override val code: String =
     """
       |class Foo {
-      | int foo(int x, int y) {
-      |  if (y < 10)
-      |    return -1;
-      |  if (x < 10) {
-      |   sink(x);
+      | public static int foo() {
+      |  int a = 1;
+      |  taint(a);
+      |  if (a < 10) {
+      |    bar(a);
       |  }
-      |  System.out.println("foo");
+      |  falseClean(a);
+      |  baz(a);
       |  return 0;
       | }
       |
-      | void sink(int x) {
+      | public static int taint(int z) {
+      |   return z;
+      | }
+      |
+      | public static void bar(int x) {
       |   System.out.println(x);
-      |   return;
+      | }
+      |
+      | public static int falseClean(int u) {
+      |   return u;
+      | }
+      |
+      | public static void baz(int y) {
+      |   System.out.println(y);
       | }
       |}
     """.stripMargin
 
-  "should find that parameter x in foo reaches call to sink" in {
+  "should find that parameter 'a' in Foo(a) reaches call to a condition operator" in {
     val cpg = CPG(driver.cpg.graph)
-    val List(x: MethodParameterIn) =
-      driver.nodesReachableBy(cpg.parameter("x").filter(_.method.name == "foo"), cpg.call("sink"))
-    x.name shouldBe "x"
-    x.method.name shouldBe "foo"
+
+    val r = driver
+      .nodesReachableBy(cpg.parameter("a"), cpg.call("<operator>.*"))
+    val List(v1) = r.map(r => r.path.map(x => (x.node.method.name, x.node.code)))
+
+    v1.head shouldBe ("foo", "int a")
+    v1.last shouldBe ("foo", "a >= 10")
   }
 
-  "should find that parameter y reaches call to a condition operator" in {
+  "should find that parameter 'a' in Foo(a) reaches call to baz" in {
     val cpg = CPG(driver.cpg.graph)
-    val List(x: MethodParameterIn) =
-      driver.nodesReachableBy(cpg.parameter("y"), cpg.call(Operators.greaterEqualsThan))
-    x.name shouldBe "y"
-    x.method.name shouldBe "foo"
+
+    val r = driver
+      .nodesReachableBy(cpg.parameter("a"), cpg.call("bar"))
+    val List(v1) = r.map(r => r.path.map(x => (x.node.method.name, x.node.code)))
+
+    v1.head shouldBe ("foo", "int a")
+    v1.last shouldBe ("foo", "bar(a)")
   }
 
-  "should find that System.out.println in sink is reached by both x parameters" in {
+  "should find that parameter 'a' in Foo(a) should reach println(y) in bar and baz via two flows" in {
     val cpg = CPG(driver.cpg.graph)
-    val List(fooX: MethodParameterIn, sinkX: MethodParameterIn) =
-      driver.nodesReachableBy(cpg.parameter("x"), cpg.call("println"))
-    fooX.name shouldBe "x"
-    fooX.method.name shouldBe "foo"
-    sinkX.name shouldBe "x"
-    sinkX.method.name shouldBe "sink"
+
+    val r = driver
+      .nodesReachableBy(cpg.parameter("a"), cpg.call("println"))
+
+    r.size shouldBe 2
+
+    val List(v1, v2) = r.map(r => r.path.map(x => (x.node.method.name, x.node.code)))
+
+    v1.head shouldBe ("foo", "int a")
+    v1.last shouldBe ("baz", "$stack1.println(y)")
+    v2.head shouldBe ("foo", "int a")
+    v2.last shouldBe ("bar", "$stack1.println(x)")
+  }
+
+  "should find that System.out.println in baz is not reached if clean is set as a sanitizer" in {
+    val cpg = CPG(driver.cpg.graph)
+
+    def source = cpg.parameter("a")
+    def sink   = cpg.call("baz")
+    val r1     = driver.nodesReachableBy(source, sink)
+
+    r1.size shouldBe 1
+
+    val List(v1) = r1.map(r =>
+      r.path.map(x =>
+        (x.node.method.name, x.node.astParent.code, x.node.astParent.property("METHOD_FULL_NAME"))
+      )
+    )
+
+    val r2 = driver.nodesReachableBy(source, sink, Set("Foo.falseClean:int(int)"))
+
+    r2.size shouldBe 0
   }
 
 }


### PR DESCRIPTION
### Added

- `OverflowDbDriver::nodesReachableBy` now has `sanitizers` parameter for method calls to filter paths out with.

### Related issues:

None

### Reviewer

@DavidBakerEffendi
